### PR TITLE
Harden scie-jump runtime validation.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -38,6 +38,9 @@ environment when run:
 + `LIFT`: The relative path of the default lift manifest for the current platform.
 + `EXE_EXT`: The extension to append to binaries. This is blank ("") except for Windows where it's
              ".exe".
++ `NEWLINE`: The newline characters for the current OS. This is "\n" except for Windows where it's
+             "\r\n"
+
 # Use
 
 Simply run `examples/run.sh [example name]*`. You can also pass `--no-gc` if you want artifacts

--- a/examples/cat.fetch
+++ b/examples/cat.fetch
@@ -1,0 +1,1 @@
+https://repo1.maven.org/maven2/com/github/ricksbrown/cowsay/1.1.0/cowsay-1.1.0.jar

--- a/examples/cat/lift.linux-aarch64.json
+++ b/examples/cat/lift.linux-aarch64.json
@@ -35,10 +35,7 @@
         }
       }
     },
-    "jump": {
-      "size": 1439168,
-      "version": "0.2.0"
-    }
+    "jump": null
   },
   "fetch": [
     "https://download.java.net/java/GA/jdk19.0.1/afdd2e245b014143b62ccb916125e3ce/10/GPL/openjdk-19.0.1_linux-aarch64_bin.tar.gz"

--- a/examples/cat/lift.linux-aarch64.json
+++ b/examples/cat/lift.linux-aarch64.json
@@ -1,0 +1,46 @@
+{
+  "scie": {
+    "lift": {
+      "name": "java",
+      "base": "~/.nce",
+      "files": [
+        {
+          "name": "openjdk-19.0.1_linux-aarch64_bin.tar.gz",
+          "key": "jdk",
+          "size": 194660832,
+          "hash": "88cadc91d5c7c540ea9df5d23678bb65dc2092fe4e00650b39d87f24f2328e17",
+          "type": "tar.gz"
+        },
+        {
+          "name": "cowsay-1.1.0.jar",
+          "key": "cowsay.jar",
+          "size": 1724250,
+          "hash": "212ee64546eb8b5074572fed4107d850eb90bc462aa3099c0ac8ea63fdca7811",
+          "type": "blob"
+        }
+      ],
+      "boot": {
+        "commands": {
+          "": {
+            "exe": "{jdk}/jdk-19.0.1/bin/java",
+            "args": [
+              "-jar",
+              "{cowsay.jar}"
+            ],
+            "env": {
+              "=JAVA_HOME": "{jdk}/jdk-19.0.1",
+              "=PATH": "{jdk}/jdk-19.0.1/bin:{scie.env.PATH}"
+            }
+          }
+        }
+      }
+    },
+    "jump": {
+      "size": 1439168,
+      "version": "0.2.0"
+    }
+  },
+  "fetch": [
+    "https://download.java.net/java/GA/jdk19.0.1/afdd2e245b014143b62ccb916125e3ce/10/GPL/openjdk-19.0.1_linux-aarch64_bin.tar.gz"
+  ]
+}

--- a/examples/cat/lift.linux-x86_64.json
+++ b/examples/cat/lift.linux-x86_64.json
@@ -1,0 +1,46 @@
+{
+  "scie": {
+    "lift": {
+      "name": "java",
+      "base": "~/.nce",
+      "files": [
+        {
+          "name": "openjdk-19.0.1_linux-x64_bin.tar.gz",
+          "key": "jdk",
+          "size": 195925792,
+          "hash": "7a466882c7adfa369319fe4adeb197ee5d7f79e75d641e9ef94abee1fc22b1fa",
+          "type": "tar.gz"
+        },
+        {
+          "name": "cowsay-1.1.0.jar",
+          "key": "cowsay.jar",
+          "size": 1724250,
+          "hash": "212ee64546eb8b5074572fed4107d850eb90bc462aa3099c0ac8ea63fdca7811",
+          "type": "blob"
+        }
+      ],
+      "boot": {
+        "commands": {
+          "": {
+            "exe": "{jdk}/jdk-19.0.1/bin/java",
+            "args": [
+              "-jar",
+              "{cowsay.jar}"
+            ],
+            "env": {
+              "=JAVA_HOME": "{jdk}/jdk-19.0.1",
+              "=PATH": "{jdk}/jdk-19.0.1/bin:{scie.env.PATH}"
+            }
+          }
+        }
+      }
+    },
+    "jump": {
+      "size": 1439168,
+      "version": "0.2.0"
+    }
+  },
+  "fetch": [
+    "https://download.java.net/java/GA/jdk19.0.1/afdd2e245b014143b62ccb916125e3ce/10/GPL/openjdk-19.0.1_linux-x64_bin.tar.gz"
+  ]
+}

--- a/examples/cat/lift.linux-x86_64.json
+++ b/examples/cat/lift.linux-x86_64.json
@@ -35,10 +35,7 @@
         }
       }
     },
-    "jump": {
-      "size": 1439168,
-      "version": "0.2.0"
-    }
+    "jump": null
   },
   "fetch": [
     "https://download.java.net/java/GA/jdk19.0.1/afdd2e245b014143b62ccb916125e3ce/10/GPL/openjdk-19.0.1_linux-x64_bin.tar.gz"

--- a/examples/cat/lift.macos-aarch64.json
+++ b/examples/cat/lift.macos-aarch64.json
@@ -35,10 +35,7 @@
         }
       }
     },
-    "jump": {
-      "size": 1439168,
-      "version": "0.2.0"
-    }
+    "jump": null
   },
   "fetch": [
     "https://download.java.net/java/GA/jdk19.0.1/afdd2e245b014143b62ccb916125e3ce/10/GPL/openjdk-19.0.1_macos-aarch64_bin.tar.gz"

--- a/examples/cat/lift.macos-aarch64.json
+++ b/examples/cat/lift.macos-aarch64.json
@@ -1,0 +1,46 @@
+{
+  "scie": {
+    "lift": {
+      "name": "java",
+      "base": "~/.nce",
+      "files": [
+        {
+          "name": "openjdk-19.0.1_macos-aarch64_bin.tar.gz",
+          "key": "jdk",
+          "size": 190630653,
+          "hash": "915054b18fc17216410cea7aba2321c55b82bd414e1ef3c7e1bafc7beb6856c8",
+          "type": "tar.gz"
+        },
+        {
+          "name": "cowsay-1.1.0.jar",
+          "key": "cowsay.jar",
+          "size": 1724250,
+          "hash": "212ee64546eb8b5074572fed4107d850eb90bc462aa3099c0ac8ea63fdca7811",
+          "type": "blob"
+        }
+      ],
+      "boot": {
+        "commands": {
+          "": {
+            "exe": "{jdk}/jdk-19.0.1/bin/java",
+            "args": [
+              "-jar",
+              "{cowsay.jar}"
+            ],
+            "env": {
+              "=JAVA_HOME": "{jdk}/jdk-19.0.1",
+              "=PATH": "{jdk}/jdk-19.0.1/bin:{scie.env.PATH}"
+            }
+          }
+        }
+      }
+    },
+    "jump": {
+      "size": 1439168,
+      "version": "0.2.0"
+    }
+  },
+  "fetch": [
+    "https://download.java.net/java/GA/jdk19.0.1/afdd2e245b014143b62ccb916125e3ce/10/GPL/openjdk-19.0.1_macos-aarch64_bin.tar.gz"
+  ]
+}

--- a/examples/cat/lift.macos-aarch64.json
+++ b/examples/cat/lift.macos-aarch64.json
@@ -22,14 +22,14 @@
       "boot": {
         "commands": {
           "": {
-            "exe": "{jdk}/jdk-19.0.1/bin/java",
+            "exe": "{jdk}/jdk-19.0.1.jdk/Contents/Home/bin/java",
             "args": [
               "-jar",
               "{cowsay.jar}"
             ],
             "env": {
-              "=JAVA_HOME": "{jdk}/jdk-19.0.1",
-              "=PATH": "{jdk}/jdk-19.0.1/bin:{scie.env.PATH}"
+              "=JAVA_HOME": "{jdk}/jdk-19.0.1.jdk/Contents/Home",
+              "=PATH": "{jdk}/jdk-19.0.1.jdk/Contents/Home/bin:{scie.env.PATH}"
             }
           }
         }

--- a/examples/cat/lift.macos-x86_64.json
+++ b/examples/cat/lift.macos-x86_64.json
@@ -22,14 +22,14 @@
       "boot": {
         "commands": {
           "": {
-            "exe": "{jdk}/jdk-19.0.1/bin/java",
+            "exe": "{jdk}/jdk-19.0.1.jdk/Contents/Home/bin/java",
             "args": [
               "-jar",
               "{cowsay.jar}"
             ],
             "env": {
-              "=JAVA_HOME": "{jdk}/jdk-19.0.1",
-              "=PATH": "{jdk}/jdk-19.0.1/bin:{scie.env.PATH}"
+              "=JAVA_HOME": "{jdk}/jdk-19.0.1.jdk/Contents/Home",
+              "=PATH": "{jdk}/jdk-19.0.1.jdk/Contents/Home/bin:{scie.env.PATH}"
             }
           }
         }

--- a/examples/cat/lift.macos-x86_64.json
+++ b/examples/cat/lift.macos-x86_64.json
@@ -1,0 +1,46 @@
+{
+  "scie": {
+    "lift": {
+      "name": "java",
+      "base": "~/.nce",
+      "files": [
+        {
+          "name": "openjdk-19.0.1_macos-x64_bin.tar.gz",
+          "key": "jdk",
+          "size": 192577932,
+          "hash": "469af195906979f96c1dc862c2f539a5e280d0daece493a95ebeb91962512161",
+          "type": "tar.gz"
+        },
+        {
+          "name": "cowsay-1.1.0.jar",
+          "key": "cowsay.jar",
+          "size": 1724250,
+          "hash": "212ee64546eb8b5074572fed4107d850eb90bc462aa3099c0ac8ea63fdca7811",
+          "type": "blob"
+        }
+      ],
+      "boot": {
+        "commands": {
+          "": {
+            "exe": "{jdk}/jdk-19.0.1/bin/java",
+            "args": [
+              "-jar",
+              "{cowsay.jar}"
+            ],
+            "env": {
+              "=JAVA_HOME": "{jdk}/jdk-19.0.1",
+              "=PATH": "{jdk}/jdk-19.0.1/bin:{scie.env.PATH}"
+            }
+          }
+        }
+      }
+    },
+    "jump": {
+      "size": 1439168,
+      "version": "0.2.0"
+    }
+  },
+  "fetch": [
+    "https://download.java.net/java/GA/jdk19.0.1/afdd2e245b014143b62ccb916125e3ce/10/GPL/openjdk-19.0.1_macos-x64_bin.tar.gz"
+  ]
+}

--- a/examples/cat/lift.macos-x86_64.json
+++ b/examples/cat/lift.macos-x86_64.json
@@ -35,10 +35,7 @@
         }
       }
     },
-    "jump": {
-      "size": 1439168,
-      "version": "0.2.0"
-    }
+    "jump": null
   },
   "fetch": [
     "https://download.java.net/java/GA/jdk19.0.1/afdd2e245b014143b62ccb916125e3ce/10/GPL/openjdk-19.0.1_macos-x64_bin.tar.gz"

--- a/examples/cat/lift.windows-x86_64.json
+++ b/examples/cat/lift.windows-x86_64.json
@@ -1,0 +1,46 @@
+{
+  "scie": {
+    "lift": {
+      "name": "java",
+      "base": "~/.nce",
+      "files": [
+        {
+          "name": "openjdk-19.0.1_windows-x64_bin.zip",
+          "key": "jdk",
+          "size": 194441800,
+          "hash": "adb1a33c07b45c39b926bdeeadf800f701be9c3d04e0deb543069e5f09856185",
+          "type": "zip"
+        },
+        {
+          "name": "cowsay-1.1.0.jar",
+          "key": "cowsay.jar",
+          "size": 1724250,
+          "hash": "212ee64546eb8b5074572fed4107d850eb90bc462aa3099c0ac8ea63fdca7811",
+          "type": "blob"
+        }
+      ],
+      "boot": {
+        "commands": {
+          "": {
+            "exe": "{jdk}/jdk-19.0.1/bin/java",
+            "args": [
+              "-jar",
+              "{cowsay.jar}"
+            ],
+            "env": {
+              "=JAVA_HOME": "{jdk}/jdk-19.0.1",
+              "=PATH": "{jdk}/jdk-19.0.1/bin:{scie.env.PATH}"
+            }
+          }
+        }
+      }
+    },
+    "jump": {
+      "size": 1439168,
+      "version": "0.2.0"
+    }
+  },
+  "fetch": [
+    "https://download.java.net/java/GA/jdk19.0.1/afdd2e245b014143b62ccb916125e3ce/10/GPL/openjdk-19.0.1_windows-x64_bin.zip"
+  ]
+}

--- a/examples/cat/lift.windows-x86_64.json
+++ b/examples/cat/lift.windows-x86_64.json
@@ -35,10 +35,7 @@
         }
       }
     },
-    "jump": {
-      "size": 1439168,
-      "version": "0.2.0"
-    }
+    "jump": null
   },
   "fetch": [
     "https://download.java.net/java/GA/jdk19.0.1/afdd2e245b014143b62ccb916125e3ce/10/GPL/openjdk-19.0.1_windows-x64_bin.zip"

--- a/examples/cat/test.sh
+++ b/examples/cat/test.sh
@@ -30,7 +30,7 @@ function scie_cat() {
     "${SCIE_JUMP}" \
     "${JDK}" \
     cowsay-1.1.0.jar \
-    <(echo) \
+    <(echo -en "${NEWLINE}") \
     <(
       jq -c "
       setpath([\"scie\", \"jump\", \"size\"]; ${SCIE_JUMP_SIZE})

--- a/examples/cat/test.sh
+++ b/examples/cat/test.sh
@@ -1,0 +1,61 @@
+# Copyright 2022 Science project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# shellcheck source=../common.sh
+source "${COMMON}"
+trap gc EXIT
+
+check_cmd cat chmod
+
+"${SCIE_JUMP}" "${LIFT}"
+JAVA="java${EXE_EXT}"
+gc "${PWD}/${JAVA}"
+
+sha256 "${JAVA}" > "${JAVA}.sha256"
+gc "${PWD}/${JAVA}.sha256"
+
+./"${JAVA}" "scie-jump boot-pack"
+
+# We should be able to assemble an identical scie using cat.
+JDK="$(jq -r '.scie.lift.files[0].name' "${LIFT}")"
+SCIE_CAT="java.cat${EXE_EXT}"
+gc "${PWD}/${SCIE_CAT}"
+
+function scie_cat() {
+  local expression="$1"
+  cat \
+    "${SCIE_JUMP}" \
+    "${JDK}" \
+    cowsay-1.1.0.jar \
+    <(echo) <(jq -c "${expression}" "${LIFT}") > "${SCIE_CAT}"
+  chmod +x "${SCIE_CAT}"
+}
+
+scie_cat '.'
+
+sha256 "${SCIE_CAT}" > "${SCIE_CAT}.sha256"
+gc "${PWD}/${SCIE_CAT}.sha256"
+
+./"${SCIE_CAT}" "scie cat"
+
+if [[ "$(sed "s|${JAVA}||" "${JAVA}.sha256")" == "$(sed "s|${SCIE_CAT}||" "${SCIE_CAT}.sha256")" ]];
+then
+  log "Hashes of ${JAVA} and ${SCIE_CAT} match."
+else
+  die "Hashes of ${JAVA} and ${SCIE_CAT} were not the same."
+fi
+
+scie_cat 'del(.scie.jump)'
+{
+  ./"${SCIE_CAT}" "missing jump" && die "Expected a missing scie.jump to cause a boot error."
+} || log "^- Expected boot error observed"
+
+scie_cat 'del(.scie.lift.files[0].type)'
+{
+  ./"${SCIE_CAT}" "missing jump" && die "Expected a missing file type to cause a boot error."
+} || log "^- Expected boot error observed"
+
+scie_cat 'del(.scie.lift.files[0].hash)'
+{
+  ./"${SCIE_CAT}" "missing jump" && die "Expected a missing file hash to cause a boot error."
+} || log "^- Expected boot error observed"

--- a/examples/cat/test.sh
+++ b/examples/cat/test.sh
@@ -16,6 +16,9 @@ gc "${PWD}/${JAVA}.sha256"
 
 ./"${JAVA}" "scie-jump boot-pack"
 
+SCIE_JUMP_SIZE="$(SCIE="inspect" ./"${JAVA}" | jq -r '.scie.jump.size')"
+SCIE_JUMP_VERSION="$(SCIE="inspect" ./"${JAVA}" | jq -r '.scie.jump.version')"
+
 # We should be able to assemble an identical scie using cat.
 JDK="$(jq -r '.scie.lift.files[0].name' "${LIFT}")"
 SCIE_CAT="java.cat${EXE_EXT}"
@@ -27,11 +30,18 @@ function scie_cat() {
     "${SCIE_JUMP}" \
     "${JDK}" \
     cowsay-1.1.0.jar \
-    <(echo) <(jq -c "${expression}" "${LIFT}") > "${SCIE_CAT}"
+    <(echo) \
+    <(
+      jq -c "
+      setpath([\"scie\", \"jump\", \"size\"]; ${SCIE_JUMP_SIZE})
+      | setpath([\"scie\", \"jump\", \"version\"]; \"${SCIE_JUMP_VERSION}\")
+      | ${expression}
+      " "${LIFT}"
+    ) > "${SCIE_CAT}"
   chmod +x "${SCIE_CAT}"
 }
 
-scie_cat '.'
+scie_cat "."
 
 sha256 "${SCIE_CAT}" > "${SCIE_CAT}.sha256"
 gc "${PWD}/${SCIE_CAT}.sha256"
@@ -45,17 +55,17 @@ else
   die "Hashes of ${JAVA} and ${SCIE_CAT} were not the same."
 fi
 
-scie_cat 'del(.scie.jump)'
+scie_cat "del(.scie.jump)"
 {
   ./"${SCIE_CAT}" "missing jump" && die "Expected a missing scie.jump to cause a boot error."
 } || log "^- Expected boot error observed"
 
-scie_cat 'del(.scie.lift.files[0].type)'
+scie_cat "del(.scie.lift.files[0].type)"
 {
   ./"${SCIE_CAT}" "missing jump" && die "Expected a missing file type to cause a boot error."
 } || log "^- Expected boot error observed"
 
-scie_cat 'del(.scie.lift.files[0].hash)'
+scie_cat "del(.scie.lift.files[0].hash)"
 {
   ./"${SCIE_CAT}" "missing jump" && die "Expected a missing file hash to cause a boot error."
 } || log "^- Expected boot error observed"

--- a/examples/run.sh
+++ b/examples/run.sh
@@ -123,8 +123,10 @@ LIFT="lift.${OS_ARCH}.json"
 DIST_DIR="${REPO_ROOT}/dist"
 
 EXE_EXT=""
+NEWLINE="\n"
 if [[ "${OS}" == "windows" ]]; then
   EXE_EXT=".exe"
+  NEWLINE="\r\n"
 fi
 
 SCIE_JUMP_NAME="scie-jump-${OS_ARCH}${EXE_EXT}"
@@ -138,7 +140,7 @@ fi
 )
 
 
-export ARCH EXE_EXT LIFT OS OS_ARCH SCIE_JUMP
+export ARCH EXE_EXT LIFT NEWLINE OS OS_ARCH SCIE_JUMP
 
 if (( "${#_EXAMPLE_PATHS[@]}" == 0 )); then
   for path in *; do

--- a/jump/src/lift.rs
+++ b/jump/src/lift.rs
@@ -149,7 +149,7 @@ fn assemble(
                 size: None,
                 hash: Some(hash),
                 ..
-            } => (0, hash),  // A scie-tote entry.
+            } => (0, hash), // A scie-tote entry.
             _ if reconstitute => fingerprint::digest_file(&path)?,
             file => {
                 return Err(format!(

--- a/jump/src/lift.rs
+++ b/jump/src/lift.rs
@@ -129,17 +129,33 @@ fn assemble(
 
         let file_type = if let Some(file_type) = file.file_type {
             file_type
-        } else {
+        } else if reconstitute {
             determine_file_type(&path)?
+        } else {
+            return Err(format!("A file type is required. Found: {file:?}"));
         };
 
         if reconstitute && file_type == FileType::Directory {
             path = archive::create(resolve_base, &file.name)?;
         }
-        let (size, hash) = match (file.size, file.hash) {
-            (Some(size), Some(hash)) => (size, hash),
-            (None, Some(hash)) => (0, hash),
-            _ => fingerprint::digest_file(&path)?,
+
+        let (size, hash) = match file {
+            crate::config::File {
+                size: Some(size),
+                hash: Some(hash),
+                ..
+            } => (size, hash),
+            crate::config::File {
+                size: None,
+                hash: Some(hash),
+                ..
+            } => (0, hash),  // A scie-tote entry.
+            _ if reconstitute => fingerprint::digest_file(&path)?,
+            file => {
+                return Err(format!(
+                    "Both file size and hash are required. Found: {file:?}"
+                ));
+            }
         };
 
         files.push(File {
@@ -157,7 +173,13 @@ fn assemble(
 #[time("debug")]
 pub(crate) fn load_scie(scie_path: &Path, scie_data: &[u8]) -> Result<(Jump, Lift), String> {
     let end_of_zip = crate::zip::end_of_zip(scie_data, Config::MAXIMUM_CONFIG_SIZE)?;
-    match load(scie_path, &scie_data[end_of_zip..], false)? {
+    let result = load(scie_path, &scie_data[end_of_zip..], false).map_err(|e| {
+        format!(
+            "The scie at {scie_path} has missing information in its lift manifest: {e}",
+            scie_path = scie_path.display()
+        )
+    })?;
+    match result {
         (Some(jump), lift) => Ok((jump, lift)),
         _ => Err(format!(
             "The scie at {path} has a lift manifest with no scie-jump information.",


### PR DESCRIPTION
Previously an incomplete scie assembly could be spoofed at runtime by placing maliciously crafted files relative to it.

Fixes #26