### PR TITLE
Fix blob locks.

### DIFF
--- a/examples/python/test.sh
+++ b/examples/python/test.sh
@@ -8,8 +8,19 @@ trap gc EXIT
 "${SCIE_JUMP}" "${LIFT}"
 gc "${PWD}/pants" "${PWD}/.pants.d" "${PWD}/.pids"
 
-time RUST_LOG=trace ./pants --no-pantsd -V
-time RUST_LOG=debug ./pants --no-pantsd -V
+# Observe initial install and subsequent short-circuiting of install activity.
+time RUST_LOG=trace ./pants -V
+time RUST_LOG=debug ./pants -V
 
 # Use the built-in BusyBox functionality via env var.
 SCIE_BOOT=repl ./pants -c 'from pants.util import strutil; print(strutil.__file__)'
+
+# Confirm boot bindings re-run successfully when the lift manifest changes - which allocates a new
+# boot bindings directory.
+jq '
+setpath(["extra"]; 42)
+| setpath(["scie", "lift", "name"]; "pants-extra")
+' "${LIFT}" > lift.json
+gc "${PWD}/lift.json" "${PWD}/pants-extra"
+"${SCIE_JUMP}"
+time RUST_LOG=debug ./pants-extra -V

--- a/jump/src/installer.rs
+++ b/jump/src/installer.rs
@@ -92,19 +92,12 @@ fn unpack_archive<R: Read + Seek>(
 
 #[time("debug")]
 fn unpack_blob<R: Read + Seek>(bytes: R, expected_hash: &str, dst: &Path) -> Result<(), String> {
-    let parent_dir = dst.parent().ok_or_else(|| "".to_owned())?;
-    atomic_path(parent_dir, Target::Directory, |work_dir| {
+    atomic_path(dst, Target::File, |blob_dst| {
         let mut hashed_bytes = check_hash("blob", bytes, expected_hash, dst)?;
-        let blob_dst = work_dir.join(dst.file_name().ok_or_else(|| {
-            format!(
-                "Blob destination {dst} has no file name.",
-                dst = dst.display()
-            )
-        })?);
         let mut blob_out = OpenOptions::new()
             .write(true)
             .create_new(true)
-            .open(&blob_dst)
+            .open(blob_dst)
             .map_err(|e| {
                 format!(
                     "Failed to open blob destination {blob_dst} for writing: {e}",


### PR DESCRIPTION
Previously the blob parent directory was locked instead of the blob
itself and this could lead to the blob not being re-unpacked if it
was deleted after 1st unpack.

A previously failing test of this is added to the python example where
the Pants binding command does, in fact, delete the pants.pex blob.