### PR TITLE
Support files that are lazy loaded at runtime.

### DIFF
--- a/examples/load/get.sh
+++ b/examples/load/get.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+scie_lift="$1"
+file_name="$2"
+url="$(jq -r ".get[\"${file_name}\"]" "${scie_lift}")"
+exec curl -fL "${url}"

--- a/examples/load/lift.linux-aarch64.json
+++ b/examples/load/lift.linux-aarch64.json
@@ -1,0 +1,56 @@
+{
+  "scie": {
+    "lift": {
+      "name": "cowsay",
+      "base": "~/.nce",
+      "files": [
+        {
+          "name": "get.sh"
+        },
+        {
+          "name": "cowsay-1.1.0.jar",
+          "key": "cowsay.jar",
+          "size": 1724250,
+          "hash": "212ee64546eb8b5074572fed4107d850eb90bc462aa3099c0ac8ea63fdca7811",
+          "type": "blob",
+          "source": "get"
+        },
+        {
+          "name": "openjdk-19.0.1_linux-aarch64_bin.tar.gz",
+          "key": "jdk",
+          "size": 194660832,
+          "hash": "88cadc91d5c7c540ea9df5d23678bb65dc2092fe4e00650b39d87f24f2328e17",
+          "type": "tar.gz",
+          "source": "get"
+        }
+      ],
+      "boot": {
+        "commands": {
+          "": {
+            "exe": "{jdk}/jdk-19.0.1/bin/java",
+            "args": [
+              "-jar",
+              "{cowsay.jar}"
+            ],
+            "env": {
+              "=JAVA_HOME": "{jdk}/jdk-19.0.1",
+              "=PATH": "{jdk}/jdk-19.0.1/bin:{scie.env.PATH}"
+            }
+          }
+        },
+        "bindings": {
+          "get": {
+            "exe": "{get.sh}",
+            "args": [
+              "{scie.lift}"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "get": {
+    "openjdk-19.0.1_linux-aarch64_bin.tar.gz": "https://download.java.net/java/GA/jdk19.0.1/afdd2e245b014143b62ccb916125e3ce/10/GPL/openjdk-19.0.1_linux-aarch64_bin.tar.gz",
+    "cowsay-1.1.0.jar": "https://repo1.maven.org/maven2/com/github/ricksbrown/cowsay/1.1.0/cowsay-1.1.0.jar"
+  }
+}

--- a/examples/load/lift.linux-x86_64.json
+++ b/examples/load/lift.linux-x86_64.json
@@ -1,0 +1,56 @@
+{
+  "scie": {
+    "lift": {
+      "name": "cowsay",
+      "base": "~/.nce",
+      "files": [
+        {
+          "name": "get.sh"
+        },
+        {
+          "name": "cowsay-1.1.0.jar",
+          "key": "cowsay.jar",
+          "size": 1724250,
+          "hash": "212ee64546eb8b5074572fed4107d850eb90bc462aa3099c0ac8ea63fdca7811",
+          "type": "blob",
+          "source": "get"
+        },
+        {
+          "name": "openjdk-19.0.1_linux-x64_bin.tar.gz",
+          "key": "jdk",
+          "size": 195925792,
+          "hash": "7a466882c7adfa369319fe4adeb197ee5d7f79e75d641e9ef94abee1fc22b1fa",
+          "type": "tar.gz",
+          "source": "get"
+        }
+      ],
+      "boot": {
+        "commands": {
+          "": {
+            "exe": "{jdk}/jdk-19.0.1/bin/java",
+            "args": [
+              "-jar",
+              "{cowsay.jar}"
+            ],
+            "env": {
+              "=JAVA_HOME": "{jdk}/jdk-19.0.1",
+              "=PATH": "{jdk}/jdk-19.0.1/bin:{scie.env.PATH}"
+            }
+          }
+        },
+        "bindings": {
+          "get": {
+            "exe": "{get.sh}",
+            "args": [
+              "{scie.lift}"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "get": {
+    "openjdk-19.0.1_linux-x64_bin.tar.gz": "https://download.java.net/java/GA/jdk19.0.1/afdd2e245b014143b62ccb916125e3ce/10/GPL/openjdk-19.0.1_linux-x64_bin.tar.gz",
+    "cowsay-1.1.0.jar": "https://repo1.maven.org/maven2/com/github/ricksbrown/cowsay/1.1.0/cowsay-1.1.0.jar"
+  }
+}

--- a/examples/load/lift.macos-aarch64.json
+++ b/examples/load/lift.macos-aarch64.json
@@ -1,0 +1,56 @@
+{
+  "scie": {
+    "lift": {
+      "name": "cowsay",
+      "base": "~/.nce",
+      "files": [
+        {
+          "name": "get.sh"
+        },
+        {
+          "name": "cowsay-1.1.0.jar",
+          "key": "cowsay.jar",
+          "size": 1724250,
+          "hash": "212ee64546eb8b5074572fed4107d850eb90bc462aa3099c0ac8ea63fdca7811",
+          "type": "blob",
+          "source": "curl"
+        },
+        {
+          "name": "openjdk-19.0.1_macos-aarch64_bin.tar.gz",
+          "key": "jdk",
+          "size": 190630653,
+          "hash": "915054b18fc17216410cea7aba2321c55b82bd414e1ef3c7e1bafc7beb6856c8",
+          "type": "tar.gz",
+          "source": "curl"
+        }
+      ],
+      "boot": {
+        "commands": {
+          "": {
+            "exe": "{jdk}/jdk-19.0.1.jdk/Contents/Home/bin/java",
+            "args": [
+              "-jar",
+              "{cowsay.jar}"
+            ],
+            "env": {
+              "=JAVA_HOME": "{jdk}/jdk-19.0.1.jdk/Contents/Home",
+              "=PATH": "{jdk}/jdk-19.0.1.jdk/Contents/Home/bin:{scie.env.PATH}"
+            }
+          }
+        },
+        "bindings": {
+          "curl": {
+            "exe": "{get.sh}",
+            "args": [
+              "{scie.lift}"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "get": {
+    "openjdk-19.0.1_macos-aarch64_bin.tar.gz": "https://download.java.net/java/GA/jdk19.0.1/afdd2e245b014143b62ccb916125e3ce/10/GPL/openjdk-19.0.1_macos-aarch64_bin.tar.gz",
+    "cowsay-1.1.0.jar": "https://repo1.maven.org/maven2/com/github/ricksbrown/cowsay/1.1.0/cowsay-1.1.0.jar"
+  }
+}

--- a/examples/load/lift.macos-aarch64.json
+++ b/examples/load/lift.macos-aarch64.json
@@ -13,7 +13,7 @@
           "size": 1724250,
           "hash": "212ee64546eb8b5074572fed4107d850eb90bc462aa3099c0ac8ea63fdca7811",
           "type": "blob",
-          "source": "curl"
+          "source": "get"
         },
         {
           "name": "openjdk-19.0.1_macos-aarch64_bin.tar.gz",
@@ -21,7 +21,7 @@
           "size": 190630653,
           "hash": "915054b18fc17216410cea7aba2321c55b82bd414e1ef3c7e1bafc7beb6856c8",
           "type": "tar.gz",
-          "source": "curl"
+          "source": "get"
         }
       ],
       "boot": {
@@ -39,7 +39,7 @@
           }
         },
         "bindings": {
-          "curl": {
+          "get": {
             "exe": "{get.sh}",
             "args": [
               "{scie.lift}"

--- a/examples/load/lift.macos-x86_64.json
+++ b/examples/load/lift.macos-x86_64.json
@@ -1,0 +1,56 @@
+{
+  "scie": {
+    "lift": {
+      "name": "cowsay",
+      "base": "~/.nce",
+      "files": [
+        {
+          "name": "get.sh"
+        },
+        {
+          "name": "cowsay-1.1.0.jar",
+          "key": "cowsay.jar",
+          "size": 1724250,
+          "hash": "212ee64546eb8b5074572fed4107d850eb90bc462aa3099c0ac8ea63fdca7811",
+          "type": "blob",
+          "source": "get"
+        },
+        {
+          "name": "openjdk-19.0.1_macos-x64_bin.tar.gz",
+          "key": "jdk",
+          "size": 192577932,
+          "hash": "469af195906979f96c1dc862c2f539a5e280d0daece493a95ebeb91962512161",
+          "type": "tar.gz",
+          "source": "get"
+        }
+      ],
+      "boot": {
+        "commands": {
+          "": {
+            "exe": "{jdk}/jdk-19.0.1.jdk/Contents/Home/bin/java",
+            "args": [
+              "-jar",
+              "{cowsay.jar}"
+            ],
+            "env": {
+              "=JAVA_HOME": "{jdk}/jdk-19.0.1.jdk/Contents/Home",
+              "=PATH": "{jdk}/jdk-19.0.1.jdk/Contents/Home/bin:{scie.env.PATH}"
+            }
+          }
+        },
+        "bindings": {
+          "get": {
+            "exe": "{get.sh}",
+            "args": [
+              "{scie.lift}"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "get": {
+    "openjdk-19.0.1_macos-x64_bin.tar.gz": "https://download.java.net/java/GA/jdk19.0.1/afdd2e245b014143b62ccb916125e3ce/10/GPL/openjdk-19.0.1_macos-x64_bin.tar.gz",
+    "cowsay-1.1.0.jar": "https://repo1.maven.org/maven2/com/github/ricksbrown/cowsay/1.1.0/cowsay-1.1.0.jar"
+  }
+}

--- a/examples/load/lift.windows-x86_64.json
+++ b/examples/load/lift.windows-x86_64.json
@@ -1,0 +1,57 @@
+{
+  "scie": {
+    "lift": {
+      "name": "cowsay",
+      "base": "~/.nce",
+      "files": [
+        {
+          "name": "get.sh"
+        },
+        {
+          "name": "cowsay-1.1.0.jar",
+          "key": "cowsay.jar",
+          "size": 1724250,
+          "hash": "212ee64546eb8b5074572fed4107d850eb90bc462aa3099c0ac8ea63fdca7811",
+          "type": "blob",
+          "source": "get"
+        },
+        {
+          "name": "openjdk-19.0.1_windows-x64_bin.zip",
+          "key": "jdk",
+          "size": 194441800,
+          "hash": "adb1a33c07b45c39b926bdeeadf800f701be9c3d04e0deb543069e5f09856185",
+          "type": "tar.gz",
+          "source": "get"
+        }
+      ],
+      "boot": {
+        "commands": {
+          "": {
+            "exe": "{jdk}/jdk-19.0.1/bin/java",
+            "args": [
+              "-jar",
+              "{cowsay.jar}"
+            ],
+            "env": {
+              "=JAVA_HOME": "{jdk}/jdk-19.0.1",
+              "=PATH": "{jdk}/jdk-19.0.1/bin:{scie.env.PATH}"
+            }
+          }
+        },
+        "bindings": {
+          "get": {
+            "exe": "C:\\Program Files\\Git\\usr\\bin\\bash",
+            "args": [
+              "{get.sh}",
+              "{scie.lift}"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "get": {
+    "openjdk-19.0.1_windows-x64_bin.zip": "https://download.java.net/java/GA/jdk19.0.1/afdd2e245b014143b62ccb916125e3ce/10/GPL/openjdk-19.0.1_windows-x64_bin.zip",
+    "cowsay-1.1.0.jar": "https://repo1.maven.org/maven2/com/github/ricksbrown/cowsay/1.1.0/cowsay-1.1.0.jar"
+  }
+}

--- a/examples/load/lift.windows-x86_64.json
+++ b/examples/load/lift.windows-x86_64.json
@@ -20,7 +20,7 @@
           "key": "jdk",
           "size": 194441800,
           "hash": "adb1a33c07b45c39b926bdeeadf800f701be9c3d04e0deb543069e5f09856185",
-          "type": "tar.gz",
+          "type": "zip",
           "source": "get"
         }
       ],

--- a/examples/load/test.sh
+++ b/examples/load/test.sh
@@ -1,0 +1,20 @@
+# Copyright 2022 Science project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# shellcheck source=../common.sh
+source "${COMMON}"
+trap gc EXIT
+
+check_cmd mktemp
+
+gc "${PWD}/cowsay"
+"${SCIE_JUMP}" "${LIFT}"
+
+# Force downloads to occur to exercise the load functionality even if ~/.nce has the JDK and the
+# cowsay jars already from other examples.
+SCIE_BASE="$(mktemp -d)"
+gc "${SCIE_BASE}"
+export SCIE_BASE
+
+time RUST_LOG=info ./cowsay "Curl!"
+time RUST_LOG=info ./cowsay "Local!"

--- a/jump/src/atomic.rs
+++ b/jump/src/atomic.rs
@@ -47,6 +47,19 @@ impl Target {
     }
 }
 
+fn clean(path: &Path) -> Result<(), String> {
+    if !path.exists() {
+        return Ok(());
+    }
+
+    if path.is_dir() {
+        std::fs::remove_dir(path)
+    } else {
+        std::fs::remove_file(path)
+    }
+    .map_err(|e| format!("Failed to remove path {path}: {e}", path = path.display()))
+}
+
 /// Executes work to create the `target` path exactly once across threads and processes.
 ///
 /// If the `target_type` is `Target::Directory` and the `target` directory has not yet been created,
@@ -54,13 +67,13 @@ impl Target {
 /// renamed atomically to the `target` directory path. If the `target_type` is `Target::File` and
 /// the `target` file has not been created, then `work` is handed the path of a work file to create.
 /// That work file will not exist, but its parent directories will have been already created.
-pub(crate) fn atomic_path<E: Display, F>(
+pub(crate) fn atomic_path<E: Display, T, F>(
     target: &Path,
     target_type: Target,
     work: F,
-) -> Result<(), String>
+) -> Result<Option<T>, String>
 where
-    F: FnOnce(&Path) -> Result<(), E>,
+    F: FnOnce(&Path) -> Result<T, E>,
 {
     // We use an atomic rename under a double-checked exclusive write lock to implement an atomic
     // path creation.
@@ -71,7 +84,7 @@ where
             "The atomic {target_type} at {path} has already been established.",
             path = target.display()
         );
-        return Ok(());
+        return Ok(None);
     }
 
     // Lock.
@@ -111,19 +124,27 @@ where
             (lost double-check race).",
             path = target.display()
         );
-        return Ok(());
+        return Ok(None);
     }
 
     // Act.
+
+    // N.B.: Prior work may have been terminated in ways outside the Rust runtime control (panic
+    // handling not installed, signals of various sorts); so, with the lock in hand, we clean up any
+    // stray work path before proceeding. Since we need to do this up front anyway, we do not attach
+    // cleanup to the work error path.
+    clean(&work_path)?;
+
     if Target::Directory == target_type {
         std::fs::create_dir(&work_path).map_err(|e| {
             format!(
                 "Failed to prepare workdir {work_dir}: {e}",
                 work_dir = work_path.display()
             )
-        })?;
+        })?
     }
-    work(&work_path).map_err(|e| {
+
+    let result = work(&work_path).map_err(|e| {
         format!(
             "Failed to establish atomic directory {target_dir}. Population of work directory \
             failed: {e}",
@@ -136,5 +157,6 @@ where
             failed: {e}",
             target_dir = target.display()
         )
-    })
+    })?;
+    Ok(Some(result))
 }

--- a/jump/src/config.rs
+++ b/jump/src/config.rs
@@ -132,6 +132,9 @@ pub struct File {
     #[serde(default)]
     #[serde(skip_serializing_if = "is_false")]
     pub eager_extract: bool,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
 }
 
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
@@ -375,7 +378,8 @@ mod tests {
                             size: Some(1137),
                             hash: Some("abc".to_string()),
                             file_type: Some(FileType::Blob),
-                            eager_extract: true
+                            eager_extract: true,
+                            source: None,
                         },
                         File {
                             name: "python".to_string(),
@@ -385,7 +389,8 @@ mod tests {
                             file_type: Some(FileType::Archive(ArchiveType::CompressedTar(
                                 Compression::Zstd
                             ))),
-                            eager_extract: false
+                            eager_extract: false,
+                            source: None,
                         },
                         File {
                             name: "foo.zip".to_string(),
@@ -394,6 +399,7 @@ mod tests {
                             hash: Some("def".to_string()),
                             file_type: Some(FileType::Archive(ArchiveType::Zip)),
                             eager_extract: false,
+                            source: None,
                         }
                     ],
                     boot: Boot {

--- a/jump/src/installer.rs
+++ b/jump/src/installer.rs
@@ -45,13 +45,17 @@ fn unpack_tar<R: Read>(archive_type: ArchiveType, tar_stream: R, dst: &Path) -> 
 }
 
 #[time(debug)]
-fn unpack_archive<R: Read + Seek>(
+fn unpack_archive<R: Read + Seek, T, F>(
     archive: ArchiveType,
-    bytes: R,
+    bytes_source: F,
     expected_hash: &str,
     dst: &Path,
-) -> Result<(), String> {
+) -> Result<Option<T>, String>
+where
+    F: FnOnce() -> Result<(R, T), String>,
+{
     atomic_path(dst, Target::Directory, |work_dir| {
+        let (bytes, result) = bytes_source()?;
         let hashed_bytes = check_hash(archive.as_ext(), bytes, expected_hash, dst)?;
         match archive {
             ArchiveType::Zip => {
@@ -86,13 +90,22 @@ fn unpack_archive<R: Read + Seek>(
                 })?;
                 unpack_tar(archive, zstd_decoder, work_dir)
             }
-        }
+        }?;
+        Ok::<T, String>(result)
     })
 }
 
 #[time("debug")]
-fn unpack_blob<R: Read + Seek>(bytes: R, expected_hash: &str, dst: &Path) -> Result<(), String> {
+fn unpack_blob<R: Read + Seek, T, F>(
+    bytes_source: F,
+    expected_hash: &str,
+    dst: &Path,
+) -> Result<Option<T>, String>
+where
+    F: FnOnce() -> Result<(R, T), String>,
+{
     atomic_path(dst, Target::File, |blob_dst| {
+        let (bytes, result) = bytes_source()?;
         let mut hashed_bytes = check_hash("blob", bytes, expected_hash, dst)?;
         let mut blob_out = OpenOptions::new()
             .write(true)
@@ -106,16 +119,20 @@ fn unpack_blob<R: Read + Seek>(bytes: R, expected_hash: &str, dst: &Path) -> Res
             })?;
         std::io::copy(&mut hashed_bytes, &mut blob_out)
             .map(|_| ())
-            .map_err(|e| format!("{e}"))
+            .map_err(|e| format!("{e}"))?;
+        Ok::<T, String>(result)
     })
 }
 
-fn unpack<R: Read + Seek>(
+fn unpack<R: Read + Seek, T, F>(
     file_type: FileType,
-    bytes: R,
+    bytes: F,
     expected_hash: &str,
     dst: &Path,
-) -> Result<(), String> {
+) -> Result<Option<T>, String>
+where
+    F: FnOnce() -> Result<(R, T), String>,
+{
     match file_type {
         FileType::Archive(archive_type) => unpack_archive(archive_type, bytes, expected_hash, dst),
         FileType::Blob => unpack_blob(bytes, expected_hash, dst),
@@ -135,9 +152,45 @@ pub(crate) fn install(files: &[FileEntry], payload: &[u8]) -> Result<(), String>
                     scie_tote.push((file, file.file_type, dst.clone()));
                 } else {
                     let bytes = &payload[location..(location + file.size)];
-                    unpack(file.file_type, Cursor::new(bytes), file.hash.as_str(), dst)?;
+                    unpack(
+                        file.file_type,
+                        || Ok((Cursor::new(bytes), ())),
+                        file.hash.as_str(),
+                        dst,
+                    )?;
                 }
                 file.size
+            }
+            FileEntry::LoadAndInstall((binding, file, dst)) => {
+                let buffer_source = || {
+                    info!(
+                        "Loading {file} via {exe:?}...",
+                        file = file.name,
+                        exe = binding.exe
+                    );
+                    let mut buffer = tempfile::tempfile().map_err(|e| format!("{e}"))?;
+                    let mut child = binding.spawn_stdout(vec![file.name.as_str()].as_slice())?;
+                    let mut stdout = child.stdout.take().ok_or_else(|| {
+                        format!("Failed to grab stdout attempting to load {file:?} via binding.")
+                    })?;
+                    std::io::copy(&mut stdout, &mut buffer).map_err(|e| format!("{e}"))?;
+                    buffer.seek(SeekFrom::Start(0)).map_err(|e| {
+                        format!(
+                            "Failed to re-wind temp file for reading {file:?} loaded by \
+                            {binding:?}: {e}"
+                        )
+                    })?;
+                    Ok((buffer, child))
+                };
+                if let Some(mut child) =
+                    unpack(file.file_type, buffer_source, file.hash.as_str(), dst)?
+                {
+                    let exit_status = child.wait().map_err(|e| format!("{e}"))?;
+                    if !exit_status.success() {
+                        return Err(format!("Failed to load file {file:?}: {exit_status:?}"));
+                    }
+                }
+                0
             }
             FileEntry::ScieTote((tote_file, entries)) => {
                 let scie_tote_tmpdir = tempfile::TempDir::new().map_err(|e| {
@@ -149,19 +202,43 @@ pub(crate) fn install(files: &[FileEntry], payload: &[u8]) -> Result<(), String>
                 let bytes = &payload[location..(location + tote_file.size)];
                 unpack(
                     tote_file.file_type,
-                    Cursor::new(bytes),
+                    || Ok((Cursor::new(bytes), ())),
                     tote_file.hash.as_str(),
                     &scie_tote_path,
                 )?;
                 for (file, dst) in entries {
-                    let src_path = scie_tote_path.join(&file.name);
-                    let src = std::fs::File::open(&src_path).map_err(|e| {
-                        format!(
-                            "Failed to open {file:?} at {src} from the unpacked scie-tote: {e}",
-                            src = src_path.display()
-                        )
-                    })?;
-                    unpack(file.file_type, &src, file.hash.as_str(), dst)?;
+                    let scie_tote_src = || {
+                        let src_path = scie_tote_path.join(&file.name);
+                        let file = std::fs::File::open(&src_path).map_err(|e| {
+                            format!(
+                                "Failed to open {file:?} at {src} from the unpacked scie-tote: {e}",
+                                src = src_path.display()
+                            )
+                        })?;
+                        let permissions = file
+                            .metadata()
+                            .map_err(|e| {
+                                format!(
+                                    "Failed to read permissions of {src_path}: {e}",
+                                    src_path = src_path.display()
+                                )
+                            })?
+                            .permissions();
+                        Ok((file, permissions))
+                    };
+                    if let Some(permissions) =
+                        unpack(file.file_type, scie_tote_src, file.hash.as_str(), dst)?
+                    {
+                        // We let archives handle their internally stored permission bits.
+                        if file.file_type == FileType::Blob {
+                            std::fs::set_permissions(dst, permissions).map_err(|e| {
+                                format!(
+                                    "Failed to set permissions of {dst}: {e}",
+                                    dst = dst.display()
+                                )
+                            })?;
+                        }
+                    }
                 }
                 tote_file.size
             }

--- a/jump/src/lib.rs
+++ b/jump/src/lib.rs
@@ -29,7 +29,7 @@ use crate::config::Config;
 pub use crate::config::Jump;
 // Exposed for the package crate post-processing of the scie-jump binary.
 pub use crate::jump::EOF_MAGIC;
-pub use crate::lift::{load_lift, File, Lift, ScieBoot};
+pub use crate::lift::{load_lift, File, Lift, ScieBoot, Source};
 pub use crate::process::{execute, EnvVar, EnvVars, Process};
 pub use crate::zip::check_is_zip;
 

--- a/src/boot/pack.rs
+++ b/src/boot/pack.rs
@@ -6,7 +6,7 @@ use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 
 use jump::config::{ArchiveType, FileType, Fmt};
-use jump::{check_is_zip, create_options, fingerprint, load_lift, File, Jump, Lift};
+use jump::{check_is_zip, create_options, fingerprint, load_lift, File, Jump, Lift, Source};
 use logging_timer::time;
 use proc_exit::{Code, ExitResult};
 use zip::{CompressionMethod, ZipWriter};
@@ -147,7 +147,9 @@ fn pack(
         }
     }
     for file in lift.files.iter_mut() {
-        // let (path, _) = reconstitute(resolve_base, &file.name, Some(file.file_type))?;
+        if Source::Scie != file.source {
+            continue;
+        }
         let mut path = resolve_base.join(&file.name);
         if FileType::Directory == file.file_type {
             path = path.with_extension("zip");
@@ -212,6 +214,7 @@ fn pack(
             hash,
             file_type: FileType::Archive(ArchiveType::Zip),
             eager_extract: false,
+            source: Source::Scie,
         };
 
         tote.zip_file


### PR DESCRIPTION
Files can now either be embedded in a scie or else loaded at runtime via
a binding command that takes the filename to load as an argument and
produces the file content on stdout. Hashing and size checking are still
performed by the installer.

An example is added that assumes `curl`, `jq` and `bash` are present on
the host for doing loading from the internet.

Closes #19