### PR TITLE
Fix eager scie-tote extraction.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 0.3.9
+
+This release fixes a bug that caused the scie-tote in scies using one to always be extracted and
+thus impact startup latency on warm runs.
+
 ## 0.3.8
 
 This release brings support for files with sources other than the scie itself. This allows for

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "jump"
-version = "0.3.0"
+version = "0.3.9"
 dependencies = [
  "bstr",
  "byteorder",
@@ -582,7 +582,7 @@ dependencies = [
 
 [[package]]
 name = "scie-jump"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "bstr",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 
 [package]
 name = "scie-jump"
-version = "0.3.8"
+version = "0.3.9"
 description = "The self contained interpreted executable launcher."
 authors = [
   "John Sirois <john.sirois@gmail.com>",

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,7 +1,10 @@
-# The various archive types fetched via `prepare` for the examples.
+# The various archive types fetched for the examples.
 *.jar
 *.pex
 *.tar.gz
 *.tar.xz
 *.zip
+
+# The ptex binary fetched for some examples.
+ptex-*
 

--- a/examples/ptex/lift.linux-aarch64.json
+++ b/examples/ptex/lift.linux-aarch64.json
@@ -1,0 +1,60 @@
+{
+  "scie": {
+    "lift": {
+      "name": "cowsay",
+      "files": [
+        {
+          "name": "ptex-linux-aarch64",
+          "key": "ptex",
+          "executable": true
+        },
+        {
+          "name": "cowsay-1.1.0.jar",
+          "key": "cowsay.jar",
+          "size": 1724250,
+          "hash": "212ee64546eb8b5074572fed4107d850eb90bc462aa3099c0ac8ea63fdca7811",
+          "type": "blob",
+          "source": "ptex-fetch"
+        },
+        {
+          "name": "openjdk-19.0.1_linux-aarch64_bin.tar.gz",
+          "key": "jdk",
+          "size": 194660832,
+          "hash": "88cadc91d5c7c540ea9df5d23678bb65dc2092fe4e00650b39d87f24f2328e17",
+          "type": "tar.gz",
+          "source": "ptex-fetch"
+        }
+      ],
+      "boot": {
+        "commands": {
+          "": {
+            "exe": "{jdk}/jdk-19.0.1/bin/java",
+            "args": [
+              "-jar",
+              "{cowsay.jar}"
+            ],
+            "env": {
+              "=JAVA_HOME": "{jdk}/jdk-19.0.1",
+              "=PATH": "{jdk}/jdk-19.0.1/bin:{scie.env.PATH}"
+            }
+          }
+        },
+        "bindings": {
+          "ptex-fetch": {
+            "exe": "{ptex}",
+            "args": [
+              "{scie.lift}"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "fetch": [
+    "https://github.com/a-scie/ptex/releases/download/v0.1.14/ptex-linux-aarch64"
+  ],
+  "ptex": {
+    "openjdk-19.0.1_linux-aarch64_bin.tar.gz": "https://download.java.net/java/GA/jdk19.0.1/afdd2e245b014143b62ccb916125e3ce/10/GPL/openjdk-19.0.1_linux-aarch64_bin.tar.gz",
+    "cowsay-1.1.0.jar": "https://repo1.maven.org/maven2/com/github/ricksbrown/cowsay/1.1.0/cowsay-1.1.0.jar"
+  }
+}

--- a/examples/ptex/lift.linux-x86_64.json
+++ b/examples/ptex/lift.linux-x86_64.json
@@ -1,0 +1,60 @@
+{
+  "scie": {
+    "lift": {
+      "name": "cowsay",
+      "files": [
+        {
+          "name": "ptex-linux-x86_64",
+          "key": "ptex",
+          "executable": true
+        },
+        {
+          "name": "cowsay-1.1.0.jar",
+          "key": "cowsay.jar",
+          "size": 1724250,
+          "hash": "212ee64546eb8b5074572fed4107d850eb90bc462aa3099c0ac8ea63fdca7811",
+          "type": "blob",
+          "source": "ptex-fetch"
+        },
+        {
+          "name": "openjdk-19.0.1_linux-x64_bin.tar.gz",
+          "key": "jdk",
+          "size": 195925792,
+          "hash": "7a466882c7adfa369319fe4adeb197ee5d7f79e75d641e9ef94abee1fc22b1fa",
+          "type": "tar.gz",
+          "source": "ptex-fetch"
+        }
+      ],
+      "boot": {
+        "commands": {
+          "": {
+            "exe": "{jdk}/jdk-19.0.1/bin/java",
+            "args": [
+              "-jar",
+              "{cowsay.jar}"
+            ],
+            "env": {
+              "=JAVA_HOME": "{jdk}/jdk-19.0.1",
+              "=PATH": "{jdk}/jdk-19.0.1/bin:{scie.env.PATH}"
+            }
+          }
+        },
+        "bindings": {
+          "ptex-fetch": {
+            "exe": "{ptex}",
+            "args": [
+              "{scie.lift}"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "fetch": [
+    "https://github.com/a-scie/ptex/releases/download/v0.1.14/ptex-linux-x86_64"
+  ],
+  "ptex": {
+    "openjdk-19.0.1_linux-x64_bin.tar.gz": "https://download.java.net/java/GA/jdk19.0.1/afdd2e245b014143b62ccb916125e3ce/10/GPL/openjdk-19.0.1_linux-x64_bin.tar.gz",
+    "cowsay-1.1.0.jar": "https://repo1.maven.org/maven2/com/github/ricksbrown/cowsay/1.1.0/cowsay-1.1.0.jar"
+  }
+}

--- a/examples/ptex/lift.macos-aarch64.json
+++ b/examples/ptex/lift.macos-aarch64.json
@@ -1,0 +1,60 @@
+{
+  "scie": {
+    "lift": {
+      "name": "cowsay",
+      "files": [
+        {
+          "name": "ptex-macos-aarch64",
+          "key": "ptex",
+          "executable": true
+        },
+        {
+          "name": "cowsay-1.1.0.jar",
+          "key": "cowsay.jar",
+          "size": 1724250,
+          "hash": "212ee64546eb8b5074572fed4107d850eb90bc462aa3099c0ac8ea63fdca7811",
+          "type": "blob",
+          "source": "ptex-fetch"
+        },
+        {
+          "name": "openjdk-19.0.1_macos-aarch64_bin.tar.gz",
+          "key": "jdk",
+          "size": 190630653,
+          "hash": "915054b18fc17216410cea7aba2321c55b82bd414e1ef3c7e1bafc7beb6856c8",
+          "type": "tar.gz",
+          "source": "ptex-fetch"
+        }
+      ],
+      "boot": {
+        "commands": {
+          "": {
+            "exe": "{jdk}/jdk-19.0.1.jdk/Contents/Home/bin/java",
+            "args": [
+              "-jar",
+              "{cowsay.jar}"
+            ],
+            "env": {
+              "=JAVA_HOME": "{jdk}/jdk-19.0.1.jdk/Contents/Home",
+              "=PATH": "{jdk}/jdk-19.0.1.jdk/Contents/Home/bin:{scie.env.PATH}"
+            }
+          }
+        },
+        "bindings": {
+          "ptex-fetch": {
+            "exe": "{ptex}",
+            "args": [
+              "{scie.lift}"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "fetch": [
+    "https://github.com/a-scie/ptex/releases/download/v0.1.14/ptex-macos-aarch64"
+  ],
+  "ptex": {
+    "openjdk-19.0.1_macos-aarch64_bin.tar.gz": "https://download.java.net/java/GA/jdk19.0.1/afdd2e245b014143b62ccb916125e3ce/10/GPL/openjdk-19.0.1_macos-aarch64_bin.tar.gz",
+    "cowsay-1.1.0.jar": "https://repo1.maven.org/maven2/com/github/ricksbrown/cowsay/1.1.0/cowsay-1.1.0.jar"
+  }
+}

--- a/examples/ptex/lift.macos-x86_64.json
+++ b/examples/ptex/lift.macos-x86_64.json
@@ -1,0 +1,60 @@
+{
+  "scie": {
+    "lift": {
+      "name": "cowsay",
+      "files": [
+        {
+          "name": "ptex-macos-x86_64",
+          "key": "ptex",
+          "executable": true
+        },
+        {
+          "name": "cowsay-1.1.0.jar",
+          "key": "cowsay.jar",
+          "size": 1724250,
+          "hash": "212ee64546eb8b5074572fed4107d850eb90bc462aa3099c0ac8ea63fdca7811",
+          "type": "blob",
+          "source": "ptex-fetch"
+        },
+        {
+          "name": "openjdk-19.0.1_macos-x64_bin.tar.gz",
+          "key": "jdk",
+          "size": 192577932,
+          "hash": "469af195906979f96c1dc862c2f539a5e280d0daece493a95ebeb91962512161",
+          "type": "tar.gz",
+          "source": "ptex-fetch"
+        }
+      ],
+      "boot": {
+        "commands": {
+          "": {
+            "exe": "{jdk}/jdk-19.0.1.jdk/Contents/Home/bin/java",
+            "args": [
+              "-jar",
+              "{cowsay.jar}"
+            ],
+            "env": {
+              "=JAVA_HOME": "{jdk}/jdk-19.0.1.jdk/Contents/Home",
+              "=PATH": "{jdk}/jdk-19.0.1.jdk/Contents/Home/bin:{scie.env.PATH}"
+            }
+          }
+        },
+        "bindings": {
+          "ptex-fetch": {
+            "exe": "{ptex}",
+            "args": [
+              "{scie.lift}"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "fetch": [
+    "https://github.com/a-scie/ptex/releases/download/v0.1.14/ptex-macos-x86_64"
+  ],
+  "ptex": {
+    "openjdk-19.0.1_macos-x64_bin.tar.gz": "https://download.java.net/java/GA/jdk19.0.1/afdd2e245b014143b62ccb916125e3ce/10/GPL/openjdk-19.0.1_macos-x64_bin.tar.gz",
+    "cowsay-1.1.0.jar": "https://repo1.maven.org/maven2/com/github/ricksbrown/cowsay/1.1.0/cowsay-1.1.0.jar"
+  }
+}

--- a/examples/ptex/lift.windows-x86_64.json
+++ b/examples/ptex/lift.windows-x86_64.json
@@ -1,0 +1,59 @@
+{
+  "scie": {
+    "lift": {
+      "name": "cowsay",
+      "files": [
+        {
+          "name": "ptex-windows-x86_64.exe",
+          "key": "ptex"
+        },
+        {
+          "name": "cowsay-1.1.0.jar",
+          "key": "cowsay.jar",
+          "size": 1724250,
+          "hash": "212ee64546eb8b5074572fed4107d850eb90bc462aa3099c0ac8ea63fdca7811",
+          "type": "blob",
+          "source": "ptex-fetch"
+        },
+        {
+          "name": "openjdk-19.0.1_windows-x64_bin.zip",
+          "key": "jdk",
+          "size": 194441800,
+          "hash": "adb1a33c07b45c39b926bdeeadf800f701be9c3d04e0deb543069e5f09856185",
+          "type": "zip",
+          "source": "ptex-fetch"
+        }
+      ],
+      "boot": {
+        "commands": {
+          "": {
+            "exe": "{jdk}/jdk-19.0.1/bin/java",
+            "args": [
+              "-jar",
+              "{cowsay.jar}"
+            ],
+            "env": {
+              "=JAVA_HOME": "{jdk}/jdk-19.0.1",
+              "=PATH": "{jdk}/jdk-19.0.1/bin:{scie.env.PATH}"
+            }
+          }
+        },
+        "bindings": {
+          "ptex-fetch": {
+            "exe": "{ptex}",
+            "args": [
+              "{scie.lift}"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "fetch": [
+    "https://github.com/a-scie/ptex/releases/download/v0.1.14/ptex-windows-x86_64.exe"
+  ],
+  "ptex": {
+    "openjdk-19.0.1_windows-x64_bin.zip": "https://download.java.net/java/GA/jdk19.0.1/afdd2e245b014143b62ccb916125e3ce/10/GPL/openjdk-19.0.1_windows-x64_bin.zip",
+    "cowsay-1.1.0.jar": "https://repo1.maven.org/maven2/com/github/ricksbrown/cowsay/1.1.0/cowsay-1.1.0.jar"
+  }
+}

--- a/examples/ptex/test.sh
+++ b/examples/ptex/test.sh
@@ -1,0 +1,20 @@
+# Copyright 2022 Science project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# shellcheck source=../common.sh
+source "${COMMON}"
+trap gc EXIT
+
+check_cmd mktemp
+
+gc "${PWD}/cowsay"
+"${SCIE_JUMP}" "${LIFT}"
+
+# Force downloads to occur to exercise the load functionality even if ~/.nce has the JDK and the
+# cowsay jars already from other examples.
+SCIE_BASE="$(mktemp -d)"
+gc "${SCIE_BASE}"
+export SCIE_BASE
+
+time RUST_LOG=info ./cowsay "PTEX!"
+time RUST_LOG=info ./cowsay "Local!"

--- a/jump/Cargo.toml
+++ b/jump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jump"
-version = "0.3.0"
+version = "0.3.9"
 description = "The bulk of the scie-jump binary logic."
 authors = [
     "John Sirois <john.sirois@gmail.com>",


### PR DESCRIPTION
Previously a scie utilizing a scie-tote would extract that scie-tote on
every run whether or not the file entries of the scie-tote had already
been extracted themselves. Fix this and add a ptex example which is
where this issue was 1st discovered.

Fixes #43