### PR TITLE
Switch to musl for Linux releases.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,6 +9,3 @@ rustflags = [
     # For Windows static msvcrt linking with no need for dll re-distribution.
     "-C", "target-feature=+crt-static"
 ]
-
-[unstable]
-bindeps = true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ orbs:
   rust: circleci/rust@1.6.0
 
 jobs:
-  package:
+  test:
     machine:
       image: ubuntu-2004:current
     resource_class: arm.medium
@@ -28,13 +28,31 @@ jobs:
       - checkout
       - rust/install:
           version: nightly
-      - rust/cargo-run:
-          package: --release -p package dist
+      - rust/format:
+          nightly-toolchain: true
+      - rust/install
+      - rust/clippy
+      - rust/test
+  package:
+    machine:
+      image: ubuntu-2004:current
+    resource_class: arm.medium
+    steps:
+      - checkout
+      - run:
+          name: Package scie-jump
+          command: |
+            mkdir dist
+            docker run --rm \
+              -v $PWD:/code \
+              -w /code \
+              rust:1.65.0-alpine3.15 \
+                sh -c 'apk add cmake make musl-dev perl && cargo run -p package -- dist'
       - persist_to_workspace:
           root: dist
           paths:
             - scie-jump*
-  test:
+  integration-test:
     machine:
       image: ubuntu-2004:current
     resource_class: arm.medium
@@ -60,8 +78,9 @@ jobs:
 workflows:
   ci:
     jobs:
+      - test
       - package
-      - test:
+      - integration-test:
           requires:
             - package
   release:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,12 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - dependabot/**
+  pull_request:
 defaults:
   run:
     shell: bash
-env:
-  CARGO_TERM_COLOR: always
 concurrency:
   group: CI-${{ github.ref }}
   # Queue on all branches and tags, but only cancel overlapping PR burns.
@@ -27,12 +29,24 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Check Formatting
-        run: cargo fmt --check --all
+        run: |
+          rustup toolchain add nightly -c rustfmt
+          cargo +nightly fmt --check --all
       - name: Lint
         run: cargo clippy --all
       - name: Unit Tests
         run: cargo test --all
       - name: Build & Package
-        run: cargo run --release -p package dist
+        if: ${{ matrix.os != 'ubuntu-20.04' }}
+        run: cargo run -p package
+      - name: Build & Package
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
+        run: |
+          mkdir dist
+          docker run --rm \
+            -v $PWD:/code \
+            -w /code \
+            rust:1.65.0-alpine3.15 \
+              sh -c 'apk add cmake make musl-dev perl && cargo run -p package'
       - name: Integration Tests
-        run: examples/run.sh
+        run: examples/run.sh --no-package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,17 @@ jobs:
         with:
           ref: ${{ needs.determine-tag.outputs.release-tag }}
       - name: Package scie-jump ${{ needs.determine-tag.outputs.release-tag }} binary
-        run: cargo run --release -p package dist
+        if: ${{ matrix.os != 'ubuntu-20.04' }}
+        run: cargo run -p package -- dist
+      - name: Package scie-jump ${{ needs.determine-tag.outputs.release-tag }} binary
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
+        run: |
+          mkdir dist
+          docker run --rm \
+            -v $PWD:/code \
+            -w /code \
+            rust:1.65.0-alpine3.15 \
+              sh -c 'apk add cmake make musl-dev perl && cargo run -p package -- dist'
       - name: Prepare Changelog
         id: prepare-changelog
         uses: a-scie/actions/changelog@v1.3

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.5.0
+
+This release brings fully static binaries for Linux with zero runtime
+linkage by switching the Linux targets to use musl. As part of this
+switch, the Rust toolchain used is stabilized to stable / 1.65.0.
+
 ## 0.4.0
 
 This release beings support for `{scie.env.*}` defaults which allows for ptex'ed scies that opt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "4.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d63b9e9c07271b9957ad22c173bae2a4d9a81127680962039296abcd2f8251d"
+dependencies = [
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "is-terminal",
+ "once_cell",
+ "strsim",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote 1.0.21",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,9 +195,9 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "env_logger"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c90bf5f19754d10198ccb95b70664fc925bd1fc090a0fd9a6ebc54acc8cd6272"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
 dependencies = [
  "log",
 ]
@@ -202,7 +239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e11dcc7e4d79a8c89b9ab4c6f5c30b1fc4a83c420792da3542fd31179ed5f517"
 dependencies = [
  "cfg-if",
- "rustix",
+ "rustix 0.35.12",
  "windows-sys 0.36.1",
 ]
 
@@ -256,6 +293,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +331,28 @@ name = "io-lifetimes"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e481ccbe3dea62107216d0d1138bb8ad8e5e5c43009a098bd1990272c497b0"
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+dependencies = [
+ "libc",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927609f78c2913a6f6ac3c27a4fe87f43e2a35367c0c4b0f8265e8f49a104330"
+dependencies = [
+ "hermit-abi",
+ "io-lifetimes 1.0.3",
+ "rustix 0.36.4",
+ "windows-sys 0.42.0",
+]
 
 [[package]]
 name = "itertools"
@@ -345,6 +419,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -404,9 +484,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
 ]
@@ -422,16 +502,16 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e322c04a9e3440c327fca7b6c8a63e6890a32fa2ad689db972425f07e0d22abb"
+checksum = "46a58d1d356c6597d08cde02c2f09d785b09e28711837b1ed667dc652c08a694"
 dependencies = [
- "autocfg",
  "bitflags",
  "cfg-if",
  "libc",
  "memoffset",
  "pin-utils",
+ "static_assertions",
 ]
 
 [[package]]
@@ -450,13 +530,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
+name = "os_str_bytes"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
 name = "package"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "byteorder",
+ "clap",
  "jump",
  "proc-exit",
- "scie-jump",
+ "sha2",
 ]
 
 [[package]]
@@ -476,6 +563,30 @@ name = "proc-exit"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2d778539881515d37cd91925d169f4a351120c5a1b44fce2b7c462b0d7f4ec6"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote 1.0.21",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.21",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro-hack"
@@ -559,10 +670,24 @@ checksum = "985947f9b6423159c4726323f373be0a21bdb514c5af06a849cb3d2dce2d01e8"
 dependencies = [
  "bitflags",
  "errno",
- "io-lifetimes",
+ "io-lifetimes 0.7.4",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.0.46",
  "windows-sys 0.36.1",
+]
+
+[[package]]
+name = "rustix"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb93e85278e08bb5788653183213d3a60fc242b10cb9be96586f5a73dcb67c23"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes 1.0.3",
+ "libc",
+ "linux-raw-sys 0.1.3",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -582,7 +707,7 @@ dependencies = [
 
 [[package]]
 name = "scie-jump"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bstr",
  "env_logger",
@@ -636,6 +761,18 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "structure"
@@ -692,6 +829,15 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -922,18 +1068,18 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.11.2+zstd.1.5.2"
+version = "0.12.0+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+checksum = "b8148aa921e9d53217ab9322f8553bd130f7ae33489db68b381d76137d2e6374"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
+version = "6.0.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+checksum = "a6cf39f730b440bab43da8fb5faf5f254574462f73f260f85f7987f32154ff17"
 dependencies = [
  "libc",
  "zstd-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 
 [package]
 name = "scie-jump"
-version = "0.4.0"
+version = "0.5.0"
 description = "The self contained interpreted executable launcher."
 authors = [
   "John Sirois <john.sirois@gmail.com>",
@@ -17,19 +17,6 @@ publish = false
 opt-level = "s"
 strip = "symbols"
 lto = "fat"
-codegen-units = 1
-
-# N.B.: The `package` psuedo-crate serves as a cross-platform build-step
-# to post-process this root crate's binary by adding a 64 bit magic
-# trailer to the binary that allows it to know its own size and know if
-# it's being run as a stub or an application. This ensures when its
-# binary dependency (this root crate) is built, it is size-optimized and
-# has symbols stripped. The lto can't be applied to a build script, but
-# that is properly plumbed to the root crate during a `-p package`
-# build.
-[profile.release.build-override]
-opt-level = "s"
-strip = "symbols"
 codegen-units = 1
 
 [workspace.dependencies]
@@ -49,11 +36,11 @@ features = ["deflate"]
 
 [dependencies]
 bstr = { workspace = true }
-env_logger = { version = "0.9", default-features = false }
+env_logger = { version = "0.10", default-features = false }
 jump = { path = "jump" }
 log = { workspace = true }
 logging_timer = { workspace = true }
-nix = "0.25"
+nix = "0.26"
 proc-exit = "2.0"
 tempfile = { workspace = true }
 zip = { workspace = true }

--- a/README.md
+++ b/README.md
@@ -136,10 +136,10 @@ of your application.
 To build an executable `scie-jump` you'll need the [Rust suite of tools](https://rustup.rs/)
 installed. With that done, simply:
 ```
-cargo run --release -p package .
+cargo run --release -p package
 ```
 
-That will deposit a `scie-jump` binary in the current directory after building it and packaging it.
+That will deposit a `scie-jump` binary in the `dist/` directory after building it and packaging it.
 The binary will have an `-<os>-<arch>` suffix that you are free to remove.
 
 ## Learn More

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,8 +6,8 @@
 
 1. Bump the version in at least [`Cargo.toml`](Cargo.toml) and possibly other crates if they were
    modified.
-2. Run `cargo run --release -p package .` to update [`Cargo.lock`](Cargo.lock) with the new version
-   and as a sanity check on the state of the project.
+2. Run `cargo run -p package` to update [`Cargo.lock`](Cargo.lock) with the new version and as a 
+   sanity check on the state of the project.
 3. Update [`CHANGES.md`](CHANGES.md) with any changes that are likely to be useful to consumers.
 4. Open a PR with these changes and land it on https://github.com/a-scie/jump main.
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -12,7 +12,7 @@ make this a bit easier. In either case you'll first need the following:
 
 There is probably a pre-built `scie-jump` binary for the platform you're targeting in our
 [releases](https://github.com/a-scie/jump/releases) that you can download. If not, you can clone
-this project on a machine of your target platform and run `cargo run --release -p package dist` and
+this project on a machine of your target platform and run `cargo run -p package` and
 a `scie-jump` binary for that platform will be deposited in the `dist/` directory. See the
 [contributing guide](../CONTRIBUTING.md) for more on the development environment setup if you're not
 already setup for Rust development.

--- a/examples/ptex/lift.linux-aarch64.json
+++ b/examples/ptex/lift.linux-aarch64.json
@@ -51,7 +51,7 @@
     }
   },
   "fetch": [
-    "https://github.com/a-scie/ptex/releases/download/v0.1.14/ptex-linux-aarch64"
+    "https://github.com/a-scie/ptex/releases/download/v0.2.0/ptex-linux-aarch64"
   ],
   "ptex": {
     "openjdk-19.0.1_linux-aarch64_bin.tar.gz": "https://download.java.net/java/GA/jdk19.0.1/afdd2e245b014143b62ccb916125e3ce/10/GPL/openjdk-19.0.1_linux-aarch64_bin.tar.gz",

--- a/examples/ptex/lift.linux-x86_64.json
+++ b/examples/ptex/lift.linux-x86_64.json
@@ -51,7 +51,7 @@
     }
   },
   "fetch": [
-    "https://github.com/a-scie/ptex/releases/download/v0.1.14/ptex-linux-x86_64"
+    "https://github.com/a-scie/ptex/releases/download/v0.2.0/ptex-linux-x86_64"
   ],
   "ptex": {
     "openjdk-19.0.1_linux-x64_bin.tar.gz": "https://download.java.net/java/GA/jdk19.0.1/afdd2e245b014143b62ccb916125e3ce/10/GPL/openjdk-19.0.1_linux-x64_bin.tar.gz",

--- a/examples/ptex/lift.macos-aarch64.json
+++ b/examples/ptex/lift.macos-aarch64.json
@@ -51,7 +51,7 @@
     }
   },
   "fetch": [
-    "https://github.com/a-scie/ptex/releases/download/v0.1.14/ptex-macos-aarch64"
+    "https://github.com/a-scie/ptex/releases/download/v0.2.0/ptex-macos-aarch64"
   ],
   "ptex": {
     "openjdk-19.0.1_macos-aarch64_bin.tar.gz": "https://download.java.net/java/GA/jdk19.0.1/afdd2e245b014143b62ccb916125e3ce/10/GPL/openjdk-19.0.1_macos-aarch64_bin.tar.gz",

--- a/examples/ptex/lift.macos-x86_64.json
+++ b/examples/ptex/lift.macos-x86_64.json
@@ -51,7 +51,7 @@
     }
   },
   "fetch": [
-    "https://github.com/a-scie/ptex/releases/download/v0.1.14/ptex-macos-x86_64"
+    "https://github.com/a-scie/ptex/releases/download/v0.2.0/ptex-macos-x86_64"
   ],
   "ptex": {
     "openjdk-19.0.1_macos-x64_bin.tar.gz": "https://download.java.net/java/GA/jdk19.0.1/afdd2e245b014143b62ccb916125e3ce/10/GPL/openjdk-19.0.1_macos-x64_bin.tar.gz",

--- a/examples/ptex/lift.windows-x86_64.json
+++ b/examples/ptex/lift.windows-x86_64.json
@@ -50,7 +50,7 @@
     }
   },
   "fetch": [
-    "https://github.com/a-scie/ptex/releases/download/v0.1.14/ptex-windows-x86_64.exe"
+    "https://github.com/a-scie/ptex/releases/download/v0.2.0/ptex-windows-x86_64.exe"
   ],
   "ptex": {
     "openjdk-19.0.1_windows-x64_bin.zip": "https://download.java.net/java/GA/jdk19.0.1/afdd2e245b014143b62ccb916125e3ce/10/GPL/openjdk-19.0.1_windows-x64_bin.zip",

--- a/examples/run.sh
+++ b/examples/run.sh
@@ -135,7 +135,7 @@ if [[ "${OS}" == "windows" ]]; then
 fi
 
 if [[ -n "${_PACKAGE}" ]]; then
-  cargo run --release -p package "${DIST_DIR}"
+  cargo run -p package -- "${DIST_DIR}"
 fi
 SCIE_JUMP_NAME="scie-jump-${OS_ARCH}${EXE_EXT}"
 SCIE_JUMP="${DIST_DIR}/${SCIE_JUMP_NAME}"

--- a/jump/Cargo.toml
+++ b/jump/Cargo.toml
@@ -29,5 +29,5 @@ tempfile = { workspace = true }
 tuple = "0.5"
 xz2 = "0.1"
 zip = { workspace = true }
-zstd = "0.11"
+zstd = "0.12"
 walkdir = "2.3"

--- a/jump/src/context.rs
+++ b/jump/src/context.rs
@@ -72,9 +72,9 @@ impl Binding {
         atomic_path(&self.target.clone(), Target::File, |lock| {
             trace!("Installing boot binding {binding:#?}", binding = &self);
             match self.process.execute() {
-                Err(err) => return Err(format!("Failed to launch boot binding: {err}")),
+                Err(err) => Err(format!("Failed to launch boot binding: {err}")),
                 Ok(exit_status) if !exit_status.success() => {
-                    return Err(format!("Boot binding command failed: {exit_status}"));
+                    Err(format!("Boot binding command failed: {exit_status}"))
                 }
                 _ => std::fs::write(lock, b"").map_err(|e| {
                     format!(

--- a/jump/src/installer.rs
+++ b/jump/src/installer.rs
@@ -21,10 +21,10 @@ fn check_hash<R: Read + Seek>(
 ) -> Result<R, String> {
     let (size, actual_hash) = fingerprint::digest_reader(&mut bytes)?;
     if expected_hash != actual_hash.as_str() {
-        return Err(format!(
+        Err(format!(
             "The {file_type} destination {dst} of size {size} had unexpected hash: {actual_hash}",
             dst = dst.display(),
-        ));
+        ))
     } else {
         // TODO(John Sirois): Hash in-line with extraction.
         bytes

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "package"
-version = "0.1.1"
+version = "0.2.0"
 description = "Packages the scie-jump binary into its final form."
 authors = [
     "John Sirois <john.sirois@gmail.com>",
@@ -8,10 +8,9 @@ authors = [
 edition = "2021"
 publish = false
 
-[build-dependencies]
-byteorder = "1.4"
-jump = { path="../jump" }
-scie-jump = { path="..", artifact="bin" }
-
 [dependencies]
+byteorder = "1.4"
+clap = { version = "4.0", features = ["derive"] }
+jump = { path = "../jump" }
 proc-exit = "2.0"
+sha2 = "0.10"

--- a/package/README.md
+++ b/package/README.md
@@ -6,7 +6,7 @@ binary.
 ## Usage
 
 ```
-cargo run [--release] -p package <output directory>
+cargo run -p package [--target TARGET (current)] [output directory (dist/)]
 ```
 
 ## Role

--- a/package/build.rs
+++ b/package/build.rs
@@ -1,58 +1,15 @@
 // Copyright 2022 Science project contributors.
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-use std::env;
-use std::path::PathBuf;
-
-use byteorder::{LittleEndian, WriteBytesExt};
-use jump::EOF_MAGIC;
-
-const SCIE_JUMP_BINARY: &str = "scie-jump";
+fn env(name: &str) -> Result<String, String> {
+    std::env::var(name).map_err(|e| format!("Expected {name} to be set for build script: {e}"))
+}
 
 fn main() -> Result<(), String> {
-    let bindep_env_var = format!("CARGO_BIN_FILE_SCIE_JUMP_{SCIE_JUMP_BINARY}");
-    let path: PathBuf = std::env::var_os(&bindep_env_var)
-        .ok_or_else(|| format!("The {bindep_env_var} environment variable was not set."))?
-        .into();
-
-    let size = u32::try_from(
-        path.metadata()
-            .map_err(|e| format!("Failed to find size of {path}: {e}", path = &path.display()))?
-            .len(),
-    )
-    .map_err(|e| format!("{e}"))?;
-
-    let mut binary = std::fs::OpenOptions::new()
-        .append(true)
-        .open(&path)
-        .map_err(|e| format!("{e}"))?;
-
-    binary
-        .write_u32::<LittleEndian>(size + 8)
-        .and_then(|()| binary.write_u32::<LittleEndian>(EOF_MAGIC))
-        .map_err(|e| format!("{e}"))?;
-
-    let dest = std::env::var("OUT_DIR")
-        .map(|path| {
-            PathBuf::from(path)
-                .join(format!(
-                    "{SCIE_JUMP_BINARY}-{os}-{arch}",
-                    os = env::consts::OS,
-                    arch = env::consts::ARCH
-                ))
-                .with_extension(env::consts::EXE_EXTENSION)
-        })
-        .map_err(|e| format!("{e}"))?;
-    std::fs::copy(path, &dest).map_err(|e| format!("{e}"))?;
-    println!("cargo:rustc-env=SCIE_STRAP={}", dest.display());
-
-    let (_, hash) = jump::fingerprint::digest_file(&dest).map_err(|e| {
-        format!(
-            "Failed to generate a sha256 hash for {dest}: {e}",
-            dest = dest.display()
-        )
-    })?;
-    println!("cargo:rustc-env=SCIE_SHA256={hash}");
-
+    println!(
+        "cargo:rustc-env=OUT_DIR={out_dir}",
+        out_dir = env("OUT_DIR")?
+    );
+    println!("cargo:rustc-env=TARGET={target}", target = env("TARGET")?);
     Ok(())
 }

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -2,48 +2,194 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 use std::env;
-use std::path::PathBuf;
+use std::fmt::{Display, Formatter};
+use std::ops::Deref;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
-use proc_exit::{Code, ExitResult};
+use byteorder::{LittleEndian, WriteBytesExt};
+use clap::Parser;
+use jump::EOF_MAGIC;
+use proc_exit::{Code, Exit, ExitResult};
+use sha2::{Digest, Sha256};
 
-fn main() -> ExitResult {
-    if std::env::args().len() != 2 {
-        return Err(Code::FAILURE.with_message(
-            "Usage: cargo run -p package <dest dir>\n\
-            \n\
-            A destination directory for the packaged scie-jump executable is \
-            required.",
-        ));
-    }
+const BINARY: &str = "scie-jump";
 
-    let src: PathBuf = env!("SCIE_STRAP").into();
-    let dst_dir: PathBuf = std::env::args().nth(1).unwrap().into();
-    let dst = {
-        let file_name = src.file_name().ok_or_else(|| {
+#[cfg(target_family = "windows")]
+const PATHSEP: &str = ";";
+
+#[cfg(target_family = "unix")]
+const PATHSEP: &str = ":";
+
+fn add_magic(path: &Path) -> ExitResult {
+    let mut binary = std::fs::OpenOptions::new()
+        .append(true)
+        .open(path)
+        .map_err(|e| {
             Code::FAILURE.with_message(format!(
-                "Expected {src} to end in a file name.",
-                src = src.display()
+                "Failed to open {BINARY} at {path} for appending the trailer magic bytes: {e}",
+                path = path.display()
             ))
         })?;
-        let dst = dst_dir.join(file_name);
-        if dst.extension().is_none() {
-            dst.with_extension(std::env::consts::EXE_EXTENSION)
-        } else {
-            dst
-        }
-    };
+    let metadata = binary.metadata().map_err(|e| {
+        Code::FAILURE.with_message(format!(
+            "Failed to load metadata for {path} to determine its size: {e}",
+            path = path.display()
+        ))
+    })?;
+    let size = u32::try_from(metadata.len()).map_err(|e| {
+        Code::FAILURE.with_message(format!(
+            "The {BINARY} at {path} is larger than expected: {e}",
+            path = path.display()
+        ))
+    })?;
+    binary
+        .write_u32::<LittleEndian>(size + 8)
+        .and_then(|()| binary.write_u32::<LittleEndian>(EOF_MAGIC))
+        .map_err(|e| {
+            Code::FAILURE.with_message(format!("Problem writing {BINARY} trailer magic bytes: {e}"))
+        })
+}
 
-    if dst_dir.is_file() {
+fn execute(command: &mut Command) -> ExitResult {
+    let mut child = command
+        .spawn()
+        .map_err(|e| Code::FAILURE.with_message(format!("{e}")))?;
+    let exit_status = child.wait().map_err(|e| {
+        Code::FAILURE.with_message(format!(
+            "Failed to gather exit status of command: {command:?}: {e}"
+        ))
+    })?;
+    if !exit_status.success() {
+        return Err(Code::FAILURE.with_message(format!(
+            "Command {command:?} failed with exit code: {code:?}",
+            code = exit_status.code()
+        )));
+    }
+    Ok(())
+}
+
+fn path_as_str(path: &Path) -> Result<&str, Exit> {
+    path.to_str().ok_or_else(|| {
+        Code::FAILURE.with_message(format!("Failed to convert path {path:?} into a UTF-8 str."))
+    })
+}
+
+#[derive(Clone)]
+struct SpecifiedPath(PathBuf);
+
+impl SpecifiedPath {
+    fn new(path: &str) -> Self {
+        Self::from(path.to_string())
+    }
+}
+
+impl From<String> for SpecifiedPath {
+    fn from(path: String) -> Self {
+        SpecifiedPath(PathBuf::from(path))
+    }
+}
+
+impl Deref for SpecifiedPath {
+    type Target = PathBuf;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AsRef<Path> for SpecifiedPath {
+    fn as_ref(&self) -> &Path {
+        self.0.as_path()
+    }
+}
+
+impl Display for SpecifiedPath {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0.display())
+    }
+}
+
+#[derive(Parser)]
+#[command(about, version)]
+struct Args {
+    #[arg(long, help = "Override the default --target for this platform.")]
+    target: Option<String>,
+    #[arg(
+        help = "The destination directory for the scie-jump binary and checksum file.",
+        default_value_t = SpecifiedPath::new("dist")
+    )]
+    dest_dir: SpecifiedPath,
+}
+
+fn main() -> ExitResult {
+    let args = Args::parse();
+    let dest_dir = args.dest_dir;
+    if dest_dir.is_file() {
         return Err(Code::FAILURE.with_message(format!(
             "The specified dest_dir of {} is a file. Not overwriting",
-            dst_dir.display()
+            dest_dir.display()
         )));
     }
 
-    std::fs::create_dir_all(&dst_dir).map_err(|e| {
+    let cargo = env!("CARGO");
+    let cargo_manifest_dir = env!("CARGO_MANIFEST_DIR");
+
+    // N.B.: OUT_DIR and TARGET are not normally available under compilation, but our custom build
+    // script forwards them.
+    let out_dir = env!("OUT_DIR");
+    let target = args.target.unwrap_or_else(|| env!("TARGET").to_string());
+    // Just in case this target is not already installed.
+    execute(Command::new("rustup").args(["target", "add", &target]))?;
+
+    let workspace_root = PathBuf::from(cargo_manifest_dir).join("..");
+    let output_root = PathBuf::from(out_dir).join("dist");
+    let output_bin_dir = output_root.join("bin");
+    execute(
+        Command::new(cargo)
+            .args([
+                "install",
+                "--path",
+                path_as_str(&workspace_root)?,
+                "--target",
+                &target,
+                "--root",
+                path_as_str(&output_root)?,
+            ])
+            // N.B.: This just suppresses a warning about adding this bin dir to your PATH.
+            .env(
+                "PATH",
+                vec![output_bin_dir.to_str().unwrap(), env!("PATH")].join(PATHSEP),
+            ),
+    )?;
+
+    let src = output_bin_dir
+        .join(BINARY)
+        .with_extension(env::consts::EXE_EXTENSION);
+    add_magic(&src)?;
+    let mut reader = std::fs::File::open(&src).map_err(|e| {
+        Code::FAILURE.with_message(format!(
+            "Failed to open {src} for hashing: {e}",
+            src = src.display()
+        ))
+    })?;
+    let mut hasher = Sha256::new();
+    std::io::copy(&mut reader, &mut hasher)
+        .map_err(|e| Code::FAILURE.with_message(format!("Failed to digest stream: {e}")))?;
+    let digest = hasher.finalize();
+
+    let file_name = format!(
+        "{BINARY}-{os}-{arch}{exe}",
+        os = env::consts::OS,
+        arch = env::consts::ARCH,
+        exe = env::consts::EXE_SUFFIX
+    );
+    let dst = dest_dir.join(&file_name);
+
+    std::fs::create_dir_all(&dest_dir).map_err(|e| {
         Code::FAILURE.with_message(format!(
             "Failed to create dest_dir {dest_dir}: {e}",
-            dest_dir = dst_dir.display()
+            dest_dir = dest_dir.display()
         ))
     })?;
     std::fs::copy(&src, &dst).map_err(|e| {
@@ -54,29 +200,17 @@ fn main() -> ExitResult {
         ))
     })?;
 
-    let file_name_raw = dst.file_name().ok_or_else(|| {
-        Code::FAILURE.with_message(format!(
-            "Expected {dst} to end in a file name.",
-            dst = dst.display()
-        ))
-    })?;
-    let file_name = file_name_raw.to_os_string().into_string().map_err(|e| {
-        Code::FAILURE.with_message(format!(
-            "Failed to interpret scie-jump file name as a utf-8 string: {e:?}"
-        ))
-    })?;
     let fingerprint_file = dst.with_file_name(format!("{file_name}.sha256"));
-    std::fs::write(
-        &fingerprint_file,
-        format!("{hash} *{file_name}\n", hash = env!("SCIE_SHA256")),
-    )
-    .map_err(|e| {
+    std::fs::write(&fingerprint_file, format!("{digest:x} *{file_name}\n")).map_err(|e| {
         Code::FAILURE.with_message(format!(
             "Failed to write fingerprint file {fingerprint_file}: {e}",
             fingerprint_file = fingerprint_file.display()
         ))
     })?;
 
-    eprintln!("Wrote the scie-jump to {}", dst.display());
+    eprintln!(
+        "Wrote the {BINARY} (target: {target}) to {dst}",
+        dst = dst.display()
+    );
     Code::SUCCESS.ok()
 }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly"
+channel = "1.65.0"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
This also stabilizes the Rust toolchain to stable / 1.65.0.

Fixes #51