### PR TITLE
Cleanup after switch to musl for Linux.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,7 @@
 [target.aarch64-pc-windows-msvc]
 rustflags = [
-  # For Windows static msvcrt linking with no need for dll re-distribution.
-  "-C", "target-feature=+crt-static"
+      # For Windows static msvcrt linking with no need for dll re-distribution.
+      "-C", "target-feature=+crt-static"
 ]
 
 [target.x86_64-pc-windows-msvc]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,8 @@ jobs:
           nightly-toolchain: true
       - rust/install
       - rust/clippy
-      - rust/test
+      - rust/test:
+          package: --all
   package:
     machine:
       image: ubuntu-2004:current
@@ -47,7 +48,7 @@ jobs:
               -v $PWD:/code \
               -w /code \
               rust:1.65.0-alpine3.15 \
-                sh -c 'apk add cmake make musl-dev perl && cargo run -p package -- dist'
+                cargo run -p package -- dist
       - persist_to_workspace:
           root: dist
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
               -v $PWD:/code \
               -w /code \
               rust:1.65.0-alpine3.15 \
-                cargo run -p package -- dist
+                sh -c 'apk add musl-dev && cargo run -p package -- dist'
       - persist_to_workspace:
           root: dist
           paths:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,6 @@ jobs:
             -v $PWD:/code \
             -w /code \
             rust:1.65.0-alpine3.15 \
-              sh -c 'apk add cmake make musl-dev perl && cargo run -p package'
+              cargo run -p package
       - name: Integration Tests
         run: examples/run.sh --no-package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,6 @@ jobs:
             -v $PWD:/code \
             -w /code \
             rust:1.65.0-alpine3.15 \
-              cargo run -p package
+              sh -c 'apk add musl-dev && cargo run -p package'
       - name: Integration Tests
         run: examples/run.sh --no-package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
             -v $PWD:/code \
             -w /code \
             rust:1.65.0-alpine3.15 \
-              sh -c 'apk add cmake make musl-dev perl && cargo run -p package -- dist'
+              cargo run -p package -- dist
       - name: Prepare Changelog
         id: prepare-changelog
         uses: a-scie/actions/changelog@v1.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
             -v $PWD:/code \
             -w /code \
             rust:1.65.0-alpine3.15 \
-              cargo run -p package -- dist
+              sh -c 'apk add musl-dev && cargo run -p package -- dist'
       - name: Prepare Changelog
         id: prepare-changelog
         uses: a-scie/actions/changelog@v1.3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,8 @@ You might want to open a [discussion](https://github.com/a-scie/jump/discussions
 https://github.com/a-scie/jump/issues) to vet your idea first. It can often save overall
 effort and lead to a better end result.
 
-The code is run through the standard `cargo` gamut. Before sending off changes you should have:
-+ Formatted the code: `cargo fmt --all`
+The code is run through the ~standard `cargo` gamut. Before sending off changes you should have:
++ Formatted the code (requires Rust nightly): `cargo +nightly fmt --all`
 + Linted the code: `cargo clippy --all`
 + Tested the code: `cargo test --all`
 
@@ -29,8 +29,9 @@ Additionally, you can run any existing integration tests using [`examples/run.sh
 Learn more about those in the [README](examples/README.md).
 
 The scie-jump binary can be built via `cargo build` but that does not produce a fully featured
-scie-jump. For that you should instead use `cargo run -p package .`. The `.` can be any directory
-where you want the final scie-jump binary deposited to. Two files will be produced:
+`scie-jump`. For that you should instead use `cargo run -p package`. That will build the scie-jump
+binary for the current machine to the `dist/` directory by default (run
+`cargo run -p package -- --help` to find out more options). Two files will be produced there:
 1. The scie jump binary: `scie-jump-<os>-<arch>(.<ext>)`
 2. The scie jump fingerprint file: `scie-jump-<os>-<arch>(.<ext>).sha256`
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = [
-  "package",
+    "package",
 ]
 
 [package]
@@ -8,7 +8,7 @@ name = "scie-jump"
 version = "0.5.0"
 description = "The self contained interpreted executable launcher."
 authors = [
-  "John Sirois <john.sirois@gmail.com>",
+    "John Sirois <john.sirois@gmail.com>",
 ]
 edition = "2021"
 publish = false

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ of your application.
 To build an executable `scie-jump` you'll need the [Rust suite of tools](https://rustup.rs/)
 installed. With that done, simply:
 ```
-cargo run --release -p package
+cargo run -p package
 ```
 
 That will deposit a `scie-jump` binary in the `dist/` directory after building it and packaging it.


### PR DESCRIPTION
Fix configuration file formatting, build docs, Circle CI testing
(currently noops / tests just the root package and not `jump`) for the
aarch64 build and minimize docker alpine based builds by removing
unneeded extra package adds.