### PR TITLE
Support SCIE={list,install} BusyBox-alikes.

### DIFF
--- a/examples/node/test.sh
+++ b/examples/node/test.sh
@@ -6,7 +6,7 @@ source "${COMMON}"
 trap gc EXIT
 
 "${SCIE_JUMP}" "${LIFT}"
-gc "${PWD}/node.js"
+gc "${PWD}/node.js${EXE_EXT}"
 
 # Get help on scie boot commands.
 SCIE="help" ./node.js
@@ -22,9 +22,17 @@ sha256 node.js* ../node.js*
 cd .. && rm -rf split
 
 # Use the built-in BusyBox functionality via binary base name.
-ln node.js "npm${EXE_EXT}"
+applets=()
+for applet in $(SCIE="list" ./node.js); do
+  applets+=("${applet}")
+done
+SCIE="install" ./node.js -s .
+for applet in ${applets[*]}; do
+  gc "${PWD}/${applet}"
+done
+
 ./npm install cowsay
-gc "${PWD}/npm" "${PWD}/node_modules" "${PWD}/package.json" "${PWD}/package-lock.json"
+gc "${PWD}/node_modules" "${PWD}/package.json" "${PWD}/package-lock.json"
 
 # Build a scie from another scie's tip-embedded scie-jump.
 SCIE="boot-pack" ./node.js "cowsay-lift.${OS_ARCH}.json"

--- a/jump/src/lib.rs
+++ b/jump/src/lib.rs
@@ -51,6 +51,13 @@ help: Display this help message.
 
 inspect: Pretty-print this scie's lift manifest to stdout.
 
+install (-s|--symlink) [dest dir]*
+
+    Install all the commands in this scie to each dest dir given. If no
+    dest dirs are given, installs them in the current directory.
+
+list: List the names of the commands contained in this scie.
+
 split [directory]?
 
     Split this scie into its component files in the given directory or
@@ -61,6 +68,8 @@ pub enum BootAction {
     Execute((Process, bool)),
     Help((String, i32)),
     Inspect((Jump, Lift)),
+    Install((PathBuf, Vec<ScieBoot>)),
+    List(Vec<ScieBoot>),
     Pack((Jump, PathBuf)),
     Select(SelectBoot),
     Split((Jump, Lift, PathBuf)),
@@ -101,6 +110,10 @@ pub fn prepare_boot(current_exe: PathBuf) -> Result<BootAction, String> {
             return Ok(BootAction::Help((format!("{HELP}\n"), 0)));
         } else if "inspect" == value {
             return Ok(BootAction::Inspect((jump, lift)));
+        } else if "install" == value {
+            return Ok(BootAction::Install((current_exe, lift.boots())));
+        } else if "list" == value {
+            return Ok(BootAction::List(lift.boots()));
         } else if "split" == value {
             return Ok(BootAction::Split((jump, lift, current_exe)));
         } else if !PathBuf::from(&value).exists() {

--- a/jump/src/lift.rs
+++ b/jump/src/lift.rs
@@ -63,6 +63,7 @@ pub struct Lift {
 pub struct ScieBoot {
     pub name: String,
     pub description: Option<String>,
+    pub default: bool,
 }
 
 impl Lift {
@@ -70,9 +71,19 @@ impl Lift {
         self.boot
             .commands
             .iter()
-            .map(|(name, cmd)| ScieBoot {
-                name: name.to_string(),
-                description: cmd.description.clone(),
+            .map(|(name, cmd)| {
+                let default = name.is_empty();
+                let name = if default {
+                    self.name.clone()
+                } else {
+                    name.to_string()
+                };
+                let description = cmd.description.clone();
+                ScieBoot {
+                    name,
+                    description,
+                    default,
+                }
             })
             .collect::<Vec<_>>()
     }

--- a/src/boot.rs
+++ b/src/boot.rs
@@ -65,10 +65,10 @@ pub(crate) fn select(select_boot: SelectBoot) -> ExitResult {
 
 #[cfg(target_family = "windows")]
 fn symlink_file(src: &Path, dst: &Path) -> ExitResult {
-    std::os::windows::fs::symlink_file;
-    symlink_file(&src, &dst).map_err(|e| {
+    use std::os::windows::fs::symlink_file;
+    symlink_file(src, dst).map_err(|e| {
         Code::FAILURE.with_message(format!(
-            "Failed to symlink {src} -> {dst}",
+            "Failed to symlink {src} -> {dst}: {e}",
             src = src.display(),
             dst = dst.display()
         ))


### PR DESCRIPTION
For the `busybox` binary these are `busybox --install (-s) dest_dir`
and `busybox --list`.

This provides an ergonomic way to ship a tool-kit.

Instead of the clunky `SCIE_BOOT=tool toolkit ...` on each and every
tool invocation you can `SCIE=install toolkit ~/bin` one time and have 
standard discoverability and ergonomics for all
`scie.lift.boot.commands`.