### PR TITLE
Various improvements fleshed out by scie-pants.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,29 @@
 # Release Notes
 
+## 0.6.0
+
+This release brings various improvements and features whose need was fleshed out by the
+[scie-pants](https://github.com/pantsbuild/scie-pants) project.
+
+Support is added for:
+
++ New placeholders:
+
+  - `{scie.base}`: The current `SCIE_BASE`.
+  - `{scie.files.<name>}`: Another way to say `{<name>}`.
+  - `{scie.files.<name>:hash}`: The sha256 hash of the named file.
+  - `{scie.bindings.<name>:<key>}`: The output named `<key>` of the named binding.
+
+  For the last, bindings have access to a `SCIE_BINDING_ENV` environment variable pointing to a
+  file they can write `<key>=<value>` lines to propagate binding information via the
+  `{scie.bindings.<name>:<key>}` placeholder.
+
++ Environment sensitive bindings:
+
+  Binding commands are now locked based on the content hash of their `env`, `exe` and `args`. This
+  allows for binding commands that are still guaranteed to run only once, but once for each unique
+  context.
+
 ## 0.5.0
 
 This release brings fully static binaries for Linux with zero runtime

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,12 +287,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,16 +299,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
-dependencies = [
- "autocfg",
- "hashbrown",
 ]
 
 [[package]]
@@ -388,7 +372,6 @@ dependencies = [
  "dirs",
  "fd-lock",
  "flate2",
- "indexmap",
  "itertools",
  "log",
  "logging_timer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 
 [package]
 name = "scie-jump"
-version = "0.5.0"
+version = "0.6.0"
 description = "The self contained interpreted executable launcher."
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -148,7 +148,12 @@ placeholder. The named binding command will be run (successfully) exactly once a
 file maintained by the scie jump. The binding command will generally want to use the
 `{scie.bindings}` to request the path of a directory (housed in the `nce` cache and namespaced by
 the lift manifest hash) set aside for that scie alone. The binding command is guaranteed it will be
-the only command operating against that directory when it is invoked.
+the only command operating against that directory when it is invoked. The binding command will be
+run with access to a `SCIE_BINDING_ENV` environment variable pointing to a file that the binding
+command can write `<key>=<value>` pairs to on individual lines. These bindings can be read by other
+commands using `{scie.bindings.<binding command name>:<key>}`. This facility is similar to the
+GitHub action [`$GITHUB_OUTPUT` facility](
+https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter).
 
 N.B.: Since the scie-jump only maintains cooperative control over the contents of the `nce` cache,
 care should be taken when designing boot binding commands. If the scie is run in a Docker container
@@ -319,6 +324,7 @@ scie. Either way though, since the scie is powered by a `scie-jump` in its tip, 
 
 Further placeholders you can use in command "exe", "args" and "env" values include:
 
++ `{scie.base}`: The value of the active `SCIE_BASE`.
 + `{scie.env.<env var name>[=<default env var value>]}`: This expands to the value of the env var
   named. If the env var is not in the ambient runtime environment and no default env var value is
   specified it expands to the empty string (""). If a default env var value is specified, it is
@@ -327,8 +333,16 @@ Further placeholders you can use in command "exe", "args" and "env" values inclu
   `{scie.env.FOO={scie.env.BAR=42}}` would evaluate to "bar" if the "FOO" env var was not set but
   the "BAR" env var was set to "bar" and it would evaluate to "42" if neither the "FOO" nor "BAR"
   env vars were set.
++ `{scie.file.<name>}`: Another way to specify a file in a command. Useful for dynamic file names.
+  Using `{{env.var.FILE_NAME}}` doesn't work since `{{` is treated as an escape that produces a
+  literal `{{`; so you can use `{scie.file.{env.var.FILE_NAME}}` instead for these cases.
++ `{scie.file:hash.<name>}`: The sha256 hash of the given file name.
 + `{scie.lift}`: This expands to the path to the lift manifest, which is extracted to disk when you
   use this placeholder. This can be used to read custom metadata stored in the lift manifest.
++ `{scie.platform}`: The `<OS>-<ARCH>` value for the current platform where `<OS>` is one of
+  `linux`, `macos` or `windows` and `<ARCH>` is either `aarch64` or `x86_64`.
++ `{scie.platform.arch}`: The current chip architecture as described by `<ARCH>` above.
++ `{scie.platform.os}`: The current operating system as described by `<OS>` above.
 
 [^1]: The binaries that Coursier releases are single-file true native binaries that do not require a
 JVM at all. As such they are ~1/3 the size of the scie we build here, which contains a full JDK

--- a/jump/Cargo.toml
+++ b/jump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jump"
-version = "0.4.0"
+version = "0.6.0"
 description = "The bulk of the scie-jump binary logic."
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/jump/Cargo.toml
+++ b/jump/Cargo.toml
@@ -15,7 +15,6 @@ bzip2 = "0.4"
 dirs = "4.0"
 fd-lock = "3.0"
 flate2 = "1.0"  # For gz support.
-indexmap = "1.9"
 itertools = "0.10"
 log = { workspace = true }
 logging_timer = { workspace = true }

--- a/jump/src/archive.rs
+++ b/jump/src/archive.rs
@@ -90,7 +90,7 @@ fn create_zip(dir: &Path) -> Result<PathBuf, String> {
     Ok(zip_path)
 }
 
-#[time("debug")]
+#[time("debug", "archive::{}")]
 pub(crate) fn create(dir: &Path, name: &str) -> Result<PathBuf, String> {
     let path = dir.join(name);
     let directory = path.canonicalize().map_err(|e| {

--- a/jump/src/fingerprint.rs
+++ b/jump/src/fingerprint.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use logging_timer::time;
 use sha2::{Digest, Sha256};
 
-#[time("debug")]
+#[time("debug", "fingerprint::{}")]
 pub fn digest(data: &[u8]) -> String {
     format!("{digest:x}", digest = Sha256::digest(data))
 }
@@ -22,7 +22,7 @@ pub fn digest_file(path: &Path) -> Result<(usize, String), String> {
     digest_reader(file)
 }
 
-#[time("debug")]
+#[time("debug", "fingerprint::{}")]
 pub fn digest_reader<R: Read>(mut reader: R) -> Result<(usize, String), String> {
     let mut hasher = Sha256::new();
     let copied_size = std::io::copy(&mut reader, &mut hasher)

--- a/jump/src/lift.rs
+++ b/jump/src/lift.rs
@@ -158,7 +158,7 @@ fn is_executable(path: &Path) -> Result<bool, String> {
     Ok(metadata.permissions().mode() & 0o111 != 0)
 }
 
-#[time("debug")]
+#[time("debug", "lift::{}")]
 fn assemble(
     resolve_base: &Path,
     config_files: Vec<crate::config::File>,
@@ -224,7 +224,7 @@ fn assemble(
     Ok(files)
 }
 
-#[time("debug")]
+#[time("debug", "lift::{}")]
 pub(crate) fn load_scie(scie_path: &Path, scie_data: &[u8]) -> Result<(Jump, Lift), String> {
     let end_of_zip = crate::zip::end_of_zip(scie_data, Config::MAXIMUM_CONFIG_SIZE)?;
     let result = load(scie_path, &scie_data[end_of_zip..], false).map_err(|e| {
@@ -242,7 +242,7 @@ pub(crate) fn load_scie(scie_path: &Path, scie_data: &[u8]) -> Result<(Jump, Lif
     }
 }
 
-#[time("debug")]
+#[time("debug", "lift::{}")]
 pub fn load_lift(manifest_path: &Path) -> Result<(Option<Jump>, Lift), String> {
     let data = std::fs::read(manifest_path).map_err(|e| {
         format!(

--- a/src/boot/pack.rs
+++ b/src/boot/pack.rs
@@ -11,7 +11,7 @@ use logging_timer::time;
 use proc_exit::{Code, ExitResult};
 use zip::{CompressionMethod, ZipWriter};
 
-#[time("debug")]
+#[time("debug", "pack::{}")]
 fn load_manifest(path: &Path, jump: &Jump) -> Result<(Lift, PathBuf), String> {
     let manifest_path = if path.is_dir() {
         path.join("lift.json")
@@ -96,7 +96,7 @@ impl ScieTote {
     }
 }
 
-#[time("debug")]
+#[time("debug", "pack::{}")]
 fn pack(
     mut lift: Lift,
     manifest_path: &Path,


### PR DESCRIPTION
Support is added for:
+ New placeholders:

  - `{scie.base}`: The current `SCIE_BASE`.
  - `{scie.files.<name>}`: Another way to say `{<name>}`.
  - `{scie.files.<name>:hash}`: The sha256 hash of the named file.
  - `{scie.bindings.<name>:<key>}`: The output named key of the named
    binding.

  For the last, bindings have access to a `SCIE_BINDING_ENV` environment
  variable pointing to a file they can write `<key>=<value>` lines to to
  propagate binding information via the `{scie.bindings.<name>:<key>}`
  placeholder.

+ Environment sensitive bindings:

  Binding commands are now locked based on the content hash of their
  env, exe and args. This allows for binding commands that are still
  guaranteed to run only once, but once for each unique context.