### PR TITLE
Clear `SCIE_BOOT` env var when redirecting via it.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.7.1
+
+This release fixes `SCIE_BOOT` re-directions to clear the `SCIE_BOOT` environment variable before
+executing the `SCIE_BOOT` selected command. This avoids the need for these commands to clear the
+`SCIE_BOOT` environment variable when re-executing the `SCIE` to avoid infinite loops.
+
 ## 0.7.0
 
 This release brings support for removing env vars to command definitions. Now, in addition to

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,7 +364,7 @@ dependencies = [
 
 [[package]]
 name = "jump"
-version = "0.6.0"
+version = "0.7.1"
 dependencies = [
  "bstr",
  "byteorder",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "scie-jump"
-version = "0.6.0"
+version = "0.7.1"
 dependencies = [
  "bstr",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 
 [package]
 name = "scie-jump"
-version = "0.7.0"
+version = "0.7.1"
 description = "The self contained interpreted executable launcher."
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/jump/Cargo.toml
+++ b/jump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jump"
-version = "0.7.0"
+version = "0.7.1"
 description = "The bulk of the scie-jump binary logic."
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/jump/src/context.rs
+++ b/jump/src/context.rs
@@ -387,6 +387,9 @@ impl<'a> Context<'a> {
 
     fn select_command(&mut self) -> Result<Option<SelectedCmd>, String> {
         if let Some(cmd) = env::var_os("SCIE_BOOT") {
+            // Avoid subprocesses that re-execute this SCIE unintentionally getting in an infinite
+            // loop.
+            env::remove_var("SCIE_BOOT");
             let name = cmd.into_string().map_err(|value| {
                 format!("Failed to decode environment variable SCIE_BOOT: {value:?}")
             })?;


### PR DESCRIPTION
This makes it easier to implement a command that re-executes the `SCIE` itself.