### PR TITLE
Support `{scie.env.*}` referring to cmd env values.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.11.0
+
+Support is added for `{scie.env.*}` placeholders referring to environment variables defined in the
+lift command environment in addition to the existing support for referring to environment variables
+defined in the ambient environment.
+
 ## 0.10.0
 
 In addition to the `SCIE` environment variable being exposed to scies, `SCIE_ARGV0` is now exposed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,6 +364,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,6 +380,17 @@ name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+ "serde",
+]
 
 [[package]]
 name = "instant"
@@ -438,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "jump"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bstr",
  "byteorder",
@@ -447,6 +464,7 @@ dependencies = [
  "dotenv",
  "fd-lock",
  "flate2",
+ "indexmap",
  "itertools",
  "log",
  "logging_timer",
@@ -751,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "scie-jump"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bstr",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 
 [package]
 name = "scie-jump"
-version = "0.10.0"
+version = "0.11.0"
 description = "The self contained interpreted executable launcher."
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -357,10 +357,12 @@ Further placeholders you can use in command "exe", "args" and "env" values inclu
 
 + `{scie.base}`: The value of the active `SCIE_BASE`.
 + `{scie.env.<env var name>[=<default env var value>]}`: This expands to the value of the env var
-  named. If the env var is not in the ambient runtime environment and no default env var value is
-  specified it expands to the empty string (""). If a default env var value is specified, it is
-  used. The default env var value specified can itself be a placeholder, in which case that is
-  expanded (recursively) to obtain the default value. For example,
+  named. If the env var is not in the ambient runtime environment or the defined command environment
+  and no default env var value is specified it expands to the empty string (""). If a default env 
+  var value is specified, it is used. The env var name can itself be composed of environment
+  placeholders, in which case they are expanded (recursively) before evaluating the env var value.
+  Likewise, the default env var value specified can also be composed of environment placeholders, in
+  which case they too are expanded (recursively) to obtain the default value. For example,
   `{scie.env.FOO={scie.env.BAR=42}}` would evaluate to "bar" if the "FOO" env var was not set but
   the "BAR" env var was set to "bar" and it would evaluate to "42" if neither the "FOO" nor "BAR"
   env vars were set.

--- a/examples/python/lift.linux-x86_64.json
+++ b/examples/python/lift.linux-x86_64.json
@@ -8,33 +8,30 @@
           "": {
             "description": "The Pants build tool.",
             "env": {
-              "=PATH": "{cpython}/python/bin:{scie.env.PATH}",
               "PEX_.*": null
             },
-            "exe": "{scie.bindings.venv}/venv/bin/python3.9",
-            "args": [
-              "{scie.bindings.venv}/venv/pex"
-            ]
+            "exe": "{scie.bindings.venv}/venv-3.{scie.env.PYTHON_MINOR=9}/pex"
           },
           "repl": {
             "description": "A Python repl with Pants (minus plugins) available for inspection.",
             "env": {
-              "=PATH": "{cpython}/python/bin:{scie.env.PATH}",
               "=PYTHONPATH": null
             },
-            "exe": "{scie.bindings.venv}/venv/bin/python3.9"
+            "exe": "{scie.bindings.venv}/venv-3.{scie.env.PYTHON_MINOR=9}/bin/python"
           }
         },
         "bindings": {
           "venv": {
             "description": "Installs Pants in a venv and pre-compiles .pyc.",
             "env": {
-              "=PATH": "{cpython}/python/bin:{scie.env.PATH}",
               "PEX_TOOLS": "1",
               "PEX_ROOT": "{scie.bindings}/pex_root",
-              "PEX_.*": null
+              "PEX_.*": null,
+              "=__PYTHON_3_8": "{cpython38}/python/bin/python3.8",
+              "=__PYTHON_3_9": "{cpython39}/python/bin/python3.9",
+              "=__PYTHON": "{scie.env.__PYTHON_3_{scie.env.PYTHON_MINOR=9}}"
             },
-            "exe": "{cpython}/python/bin/python3.9",
+            "exe": "{scie.env.__PYTHON}",
             "args": [
               "{pants.2.14.0.pex}",
               "venv",
@@ -43,15 +40,19 @@
               "--compile",
               "--rm",
               "all",
-              "{scie.bindings}/venv"
+              "{scie.bindings}/venv-3.{scie.env.PYTHON_MINOR=9}"
             ]
           }
         }
       },
       "files": [
         {
+          "name": "cpython-3.8.14+20221002-x86_64-unknown-linux-gnu-install_only.tar.gz",
+          "key": "cpython38"
+        },
+        {
           "name": "cpython-3.9.14+20221002-x86_64-unknown-linux-gnu-install_only.tar.gz",
-          "key": "cpython"
+          "key": "cpython39"
         },
         {
           "name": "pants.2.14.0.pex"
@@ -60,6 +61,7 @@
     }
   },
   "fetch": [
+    "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14+20221002-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14+20221002-x86_64-unknown-linux-gnu-install_only.tar.gz"
   ]
 }

--- a/examples/python/lift.macos-x86_64.json
+++ b/examples/python/lift.macos-x86_64.json
@@ -8,33 +8,30 @@
           "": {
             "description": "The Pants build tool.",
             "env": {
-              "=PATH": "{cpython}/python/bin:{scie.env.PATH}",
               "PEX_.*": null
             },
-            "exe": "{scie.bindings.venv}/venv/bin/python3.9",
-            "args": [
-              "{scie.bindings.venv}/venv/pex"
-            ]
+            "exe": "{scie.bindings.venv}/venv-3.{scie.env.PYTHON_MINOR=9}/pex"
           },
           "repl": {
             "description": "A Python repl with Pants (minus plugins) available for inspection.",
             "env": {
-              "=PATH": "{cpython}/python/bin:{scie.env.PATH}",
               "=PYTHONPATH": null
             },
-            "exe": "{scie.bindings.venv}/venv/bin/python3.9"
+            "exe": "{scie.bindings.venv}/venv-3.{scie.env.PYTHON_MINOR=9}/bin/python"
           }
         },
         "bindings": {
           "venv": {
             "description": "Installs Pants in a venv and pre-compiles .pyc.",
             "env": {
-              "=PATH": "{cpython}/python/bin:{scie.env.PATH}",
               "PEX_TOOLS": "1",
               "PEX_ROOT": "{scie.bindings}/pex_root",
-              "PEX_.*": null
+              "PEX_.*": null,
+              "=__PYTHON_3_8": "{cpython38}/python/bin/python3.8",
+              "=__PYTHON_3_9": "{cpython39}/python/bin/python3.9",
+              "=__PYTHON": "{scie.env.__PYTHON_3_{scie.env.PYTHON_MINOR=9}}"
             },
-            "exe": "{cpython}/python/bin/python3.9",
+            "exe": "{scie.env.__PYTHON}",
             "args": [
               "{pants.2.14.0.pex}",
               "venv",
@@ -43,26 +40,28 @@
               "--compile",
               "--rm",
               "all",
-              "{scie.bindings}/venv"
+              "{scie.bindings}/venv-3.{scie.env.PYTHON_MINOR=9}"
             ]
           }
         }
       },
       "files": [
         {
+          "name": "cpython-3.8.14+20221002-x86_64-apple-darwin-install_only.tar.gz",
+          "key": "cpython38"
+        },
+        {
           "name": "cpython-3.9.14+20221002-x86_64-apple-darwin-install_only.tar.gz",
-          "key": "cpython",
-          "hash": "b7d3a1f4b57e9350571ccee49c82f503133de0d113a2dbaebc8ccf108fb3fe1b",
-          "size": 17138819
+          "key": "cpython39"
         },
         {
           "name": "pants.2.14.0.pex",
-          "type": "zip"
         }
       ]
     }
   },
   "fetch": [
+    "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14+20221002-x86_64-apple-darwin-install_only.tar.gz",
     "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14+20221002-x86_64-apple-darwin-install_only.tar.gz"
   ]
 }

--- a/examples/python/lift.macos-x86_64.json
+++ b/examples/python/lift.macos-x86_64.json
@@ -55,7 +55,7 @@
           "key": "cpython39"
         },
         {
-          "name": "pants.2.14.0.pex",
+          "name": "pants.2.14.0.pex"
         }
       ]
     }

--- a/examples/python/test.sh
+++ b/examples/python/test.sh
@@ -40,3 +40,8 @@ setpath(["extra"]; 42)
 gc "${PWD}/lift.json" "${PWD}/pants-extra"
 "${SCIE_JUMP}"
 time RUST_LOG=debug ./pants-extra -V
+
+# Verify dynamic env var selection.
+SCIE_BOOT=repl ./pants -c 'import sys; assert (3, 9) == sys.version_info[:2]'
+PYTHON_MINOR=8 SCIE_BOOT=repl ./pants -c 'import sys; assert (3, 8) == sys.version_info[:2]'
+PYTHON_MINOR=9 SCIE_BOOT=repl ./pants -c 'import sys; assert (3, 9) == sys.version_info[:2]'

--- a/jump/Cargo.toml
+++ b/jump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jump"
-version = "0.10.0"
+version = "0.11.0"
 description = "The bulk of the scie-jump binary logic."
 authors = [
     "John Sirois <john.sirois@gmail.com>",
@@ -16,6 +16,7 @@ dirs = "4.0"
 dotenv = "0.15"
 fd-lock = "3.0"
 flate2 = "1.0"  # For gz support.
+indexmap = { version = "1.9", features = ["serde"] }
 itertools = "0.10"
 log = { workspace = true }
 logging_timer = { workspace = true }

--- a/jump/src/cmd_env.rs
+++ b/jump/src/cmd_env.rs
@@ -1,0 +1,400 @@
+// Copyright 2023 Science project contributors.
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+use std::env;
+
+use indexmap::IndexMap;
+
+use crate::config::{Cmd, EnvVar};
+use crate::placeholders;
+use crate::placeholders::{Item, Placeholder, ScieBindingEnv};
+
+#[derive(Debug)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
+pub(crate) struct ParsedEnv {
+    pub(crate) name: String,
+    pub(crate) default: Option<String>,
+}
+
+pub(crate) fn parse_scie_env_placeholder(env_var: &str) -> Result<ParsedEnv, String> {
+    match env_var.splitn(2, '=').collect::<Vec<_>>()[..] {
+        [name] => Ok(ParsedEnv {
+            name: name.to_string(),
+            default: None,
+        }),
+        [name, default] => Ok(ParsedEnv {
+            name: name.to_string(),
+            default: Some(default.to_string()),
+        }),
+        _ => Err(
+            "Expected {{scie.env.<name>}} <name> placeholder to be a non-empty string".to_string(),
+        ),
+    }
+}
+
+struct EnvParser {
+    env: IndexMap<String, String>,
+    key_stack: Vec<String>,
+    parsed: IndexMap<String, String>,
+}
+
+impl EnvParser {
+    fn new(env_vars: &IndexMap<EnvVar, Option<String>>) -> Self {
+        let mut env = IndexMap::new();
+        for (key, value) in env_vars.iter() {
+            if let Some(val) = value {
+                match key {
+                    EnvVar::Default(name) => {
+                        if env::var_os(name).is_none() {
+                            env.insert(name.to_owned(), val.to_owned());
+                        }
+                    }
+                    EnvVar::Replace(name) => {
+                        env.insert(name.to_owned(), val.to_owned());
+                    }
+                }
+            }
+        }
+        Self {
+            env,
+            key_stack: vec![],
+            parsed: IndexMap::new(),
+        }
+    }
+
+    fn reify_env(&mut self, value: &str) -> Result<String, String> {
+        let mut reified = String::with_capacity(value.len());
+        let parsed = placeholders::parse(value)?;
+        for item in &parsed.items {
+            match item {
+                Item::LeftBrace => reified.push('{'),
+                Item::Text(text) => reified.push_str(text),
+                Item::Placeholder(Placeholder::Env(name)) => {
+                    reified.push_str(&self.reify_env_var(name)?)
+                }
+                Item::Placeholder(Placeholder::FileHash(name)) => {
+                    reified.push_str(&format!("{{scie.files:hash.{name}}}"))
+                }
+                Item::Placeholder(Placeholder::FileName(name)) => {
+                    reified.push_str(&format!("{{scie.files.{name}}}"))
+                }
+                Item::Placeholder(Placeholder::Scie) => reified.push_str("{scie}"),
+                Item::Placeholder(Placeholder::ScieBase) => reified.push_str("{scie.base}"),
+                Item::Placeholder(Placeholder::ScieBindings) => reified.push_str("{scie.bindings}"),
+                Item::Placeholder(Placeholder::ScieBindingCmd(cmd)) => {
+                    reified.push_str(&format!("{{scie.bindings.{cmd}}}"))
+                }
+                Item::Placeholder(Placeholder::ScieBindingEnv(ScieBindingEnv { binding, env })) => {
+                    reified.push_str(&format!("{{scie.bindings.{binding}:{env}}}"))
+                }
+                Item::Placeholder(Placeholder::ScieLift) => reified.push_str("{scie.lift}"),
+                Item::Placeholder(Placeholder::SciePlatform) => reified.push_str("{scie.platform}"),
+                Item::Placeholder(Placeholder::SciePlatformArch) => {
+                    reified.push_str("{scie.platform.arch}")
+                }
+                Item::Placeholder(Placeholder::SciePlatformOs) => {
+                    reified.push_str("{scie.platform.os}")
+                }
+            }
+        }
+        Ok(reified)
+    }
+
+    fn reify_env_var(&mut self, name: &str) -> Result<String, String> {
+        let reified_env_name = self.reify_env(name)?;
+        let parsed_env = parse_scie_env_placeholder(&reified_env_name)?;
+        let env_val = if self.key_stack.contains(&parsed_env.name) {
+            // If we're already calculating a Cmd env var value for `key`, we can only
+            // pull references to that `key` needed to compute the value from the
+            // ambient environment.
+            if let Ok(val) = env::var(&parsed_env.name) {
+                val
+            } else {
+                parsed_env.default.unwrap_or_default()
+            }
+        } else if let Some(val) = self
+            .env
+            .get(&parsed_env.name)
+            .map(|v| v.to_owned())
+            .or_else(|| env::var(&parsed_env.name).ok())
+        {
+            self.parse_env_var(&parsed_env.name, &val)?
+        } else {
+            parsed_env.default.unwrap_or_default()
+        };
+        self.reify_env(&env_val)
+    }
+
+    fn parse_env_var(&mut self, key: &str, value: &str) -> Result<String, String> {
+        self.parse_entry(key, value)?;
+        self.parsed
+            .get(key)
+            .ok_or_else(|| format!("We just parsed an entry for {key}={value} above without error"))
+            .map(String::to_owned)
+    }
+
+    fn parse_entry(&mut self, key: &str, value: &str) -> Result<(), String> {
+        if !self.parsed.contains_key(key) {
+            self.key_stack.push(key.to_string());
+            let parsed_value = self.reify_env(value)?;
+            self.key_stack.pop();
+            self.parsed.insert(key.to_string(), parsed_value);
+        }
+        Ok(())
+    }
+
+    fn parse_env(mut self) -> Result<IndexMap<String, String>, String> {
+        for (key, value) in self.env.clone() {
+            self.parse_entry(&key, &value)?;
+        }
+        self.parsed.retain(|k, _| self.env.contains_key(k));
+        Ok(self.parsed)
+    }
+}
+
+pub(crate) fn prepare_env(cmd: &Cmd) -> Result<IndexMap<String, String>, String> {
+    EnvParser::new(&cmd.env).parse_env()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::env;
+
+    use indexmap::IndexMap;
+
+    use crate::cmd_env::{parse_scie_env_placeholder, EnvParser, ParsedEnv};
+    use crate::config::EnvVar;
+
+    #[test]
+    fn parse_env_placeholder() {
+        assert_eq!(
+            ParsedEnv {
+                name: "FOO".to_string(),
+                default: None
+            },
+            parse_scie_env_placeholder("FOO").unwrap()
+        );
+        assert_eq!(
+            ParsedEnv {
+                name: "FOO".to_string(),
+                default: Some("bar".to_string())
+            },
+            parse_scie_env_placeholder("FOO=bar").unwrap()
+        );
+        assert_eq!(
+            ParsedEnv {
+                name: "FOO".to_string(),
+                default: Some("bar=baz".to_string())
+            },
+            parse_scie_env_placeholder("FOO=bar=baz").unwrap()
+        );
+    }
+
+    #[test]
+    fn self_recurse() {
+        let env_parser = EnvParser::new(
+            &[(
+                EnvVar::Replace("PATH".to_string()),
+                Some("foo:{scie.env.PATH}".to_string()),
+            )]
+            .into_iter()
+            .collect::<IndexMap<_, _>>(),
+        );
+
+        let expected = [(
+            "PATH".to_string(),
+            format!("foo:{path}", path = env::var("PATH").unwrap()),
+        )]
+        .into_iter()
+        .collect::<IndexMap<_, _>>();
+
+        assert_eq!(expected, env_parser.parse_env().unwrap());
+    }
+
+    #[test]
+    fn multi_step_recurse() {
+        let env_parser = EnvParser::new(
+            &[
+                (
+                    EnvVar::Replace("PATH".to_string()),
+                    Some("foo:{scie.env.X}".to_string()),
+                ),
+                (
+                    EnvVar::Replace("X".to_string()),
+                    Some("{scie.env.PATH}:bar".to_string()),
+                ),
+            ]
+            .into_iter()
+            .collect::<IndexMap<_, _>>(),
+        );
+
+        let expected_path = env::var("PATH").unwrap();
+        let expected = [
+            ("PATH".to_string(), format!("foo:{expected_path}:bar")),
+            ("X".to_string(), format!("{expected_path}:bar")),
+        ]
+        .into_iter()
+        .collect::<IndexMap<_, _>>();
+
+        assert_eq!(expected, env_parser.parse_env().unwrap());
+    }
+
+    #[test]
+    fn test_dynamic_env_var_name() {
+        let cmd_env = &[
+            (
+                EnvVar::Replace("__PYTHON_3_8".to_string()),
+                Some("{cpython38}/python/bin/python3.8".to_string()),
+            ),
+            (
+                EnvVar::Replace("__PYTHON_3_9".to_string()),
+                Some("{cpython39}/python/bin/python3.9".to_string()),
+            ),
+            (
+                EnvVar::Replace("__PYTHON".to_string()),
+                Some("{scie.env.__PYTHON_3_{scie.env.__PYTHON_MINOR=9}}".to_string()),
+            ),
+        ]
+        .into_iter()
+        .collect::<IndexMap<_, _>>();
+
+        let expected = [
+            (
+                "__PYTHON_3_8".to_string(),
+                "{scie.files.cpython38}/python/bin/python3.8".to_string(),
+            ),
+            (
+                "__PYTHON_3_9".to_string(),
+                "{scie.files.cpython39}/python/bin/python3.9".to_string(),
+            ),
+            (
+                "__PYTHON".to_string(),
+                "{scie.files.cpython39}/python/bin/python3.9".to_string(),
+            ),
+        ]
+        .into_iter()
+        .collect::<IndexMap<_, _>>();
+
+        assert_eq!(expected, EnvParser::new(cmd_env).parse_env().unwrap());
+
+        env::set_var("__PYTHON_MINOR", "8");
+        let expected = [
+            (
+                "__PYTHON_3_8".to_string(),
+                "{scie.files.cpython38}/python/bin/python3.8".to_string(),
+            ),
+            (
+                "__PYTHON_3_9".to_string(),
+                "{scie.files.cpython39}/python/bin/python3.9".to_string(),
+            ),
+            (
+                "__PYTHON".to_string(),
+                "{scie.files.cpython38}/python/bin/python3.8".to_string(),
+            ),
+        ]
+        .into_iter()
+        .collect::<IndexMap<_, _>>();
+
+        assert_eq!(expected, EnvParser::new(cmd_env).parse_env().unwrap());
+    }
+
+    #[test]
+    fn test_dynamic_env_var_default() {
+        let cmd_env = [(
+            EnvVar::Replace("FOO".to_string()),
+            Some("{scie.env.BAR={scie.env.BAZ=spam}}".to_string()),
+        )]
+        .into_iter()
+        .collect::<IndexMap<_, _>>();
+
+        let expected = [("FOO".to_string(), "spam".to_string())]
+            .into_iter()
+            .collect::<IndexMap<_, _>>();
+
+        assert_eq!(expected, EnvParser::new(&cmd_env).parse_env().unwrap());
+
+        env::set_var("BAZ", "eggs");
+        let expected = [("FOO".to_string(), "eggs".to_string())]
+            .into_iter()
+            .collect::<IndexMap<_, _>>();
+
+        assert_eq!(expected, EnvParser::new(&cmd_env).parse_env().unwrap());
+        env::remove_var("BAZ");
+
+        env::set_var("BAR", "cheese");
+        let expected = [("FOO".to_string(), "cheese".to_string())]
+            .into_iter()
+            .collect::<IndexMap<_, _>>();
+
+        assert_eq!(expected, EnvParser::new(&cmd_env).parse_env().unwrap());
+        env::remove_var("BAR");
+    }
+
+    #[test]
+    fn test_excessively_dynamic_env() {
+        let cmd_env = [(
+            EnvVar::Replace("A".to_string()),
+            Some("PreA{scie.env.PreB{scie.env.B}PostB=PreC{scie.env.C=c}PostC}PostA".to_string()),
+        )]
+        .into_iter()
+        .collect::<IndexMap<_, _>>();
+
+        let expected = [("A".to_string(), "PreAPreCcPostCPostA".to_string())]
+            .into_iter()
+            .collect::<IndexMap<_, _>>();
+
+        assert_eq!(expected, EnvParser::new(&cmd_env).parse_env().unwrap());
+
+        env::set_var("C", "_Cee_");
+        let expected = [("A".to_string(), "PreAPreC_Cee_PostCPostA".to_string())]
+            .into_iter()
+            .collect::<IndexMap<_, _>>();
+
+        assert_eq!(expected, EnvParser::new(&cmd_env).parse_env().unwrap());
+        env::remove_var("C");
+
+        env::set_var("PreBPostB", "_Bee_");
+        let expected = [("A".to_string(), "PreA_Bee_PostA".to_string())]
+            .into_iter()
+            .collect::<IndexMap<_, _>>();
+
+        assert_eq!(expected, EnvParser::new(&cmd_env).parse_env().unwrap());
+        env::remove_var("PreBPostB");
+
+        env::set_var("B", "_Bee_");
+        env::set_var("PreB_Bee_PostB", "_Buzz_");
+        let expected = [("A".to_string(), "PreA_Buzz_PostA".to_string())]
+            .into_iter()
+            .collect::<IndexMap<_, _>>();
+
+        assert_eq!(expected, EnvParser::new(&cmd_env).parse_env().unwrap());
+        env::remove_var("B");
+        env::remove_var("PreB_Bee_PostB");
+    }
+
+    #[test]
+    fn test_ignored_placeholders() {
+        let env_parser = EnvParser::new(
+            &[(
+                EnvVar::Replace("PATH".to_string()),
+                Some(
+                    "{foo}:{scie.env.PATH}:{scie}:{scie.base}:{scie.files.bar}:baz{{}".to_string(),
+                ),
+            )]
+            .into_iter()
+            .collect::<IndexMap<_, _>>(),
+        );
+
+        let expected = [(
+            "PATH".to_string(),
+            format!(
+                "{{scie.files.foo}}:{path}:{{scie}}:{{scie.base}}:{{scie.files.bar}}:baz{{}}",
+                path = env::var("PATH").unwrap()
+            ),
+        )]
+        .into_iter()
+        .collect::<IndexMap<_, _>>();
+
+        assert_eq!(expected, env_parser.parse_env().unwrap());
+    }
+}

--- a/jump/src/config.rs
+++ b/jump/src/config.rs
@@ -1,11 +1,11 @@
 // Copyright 2022 Science project contributors.
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-use std::collections::BTreeMap;
 use std::fmt::Formatter;
 use std::io::Write;
 use std::path::PathBuf;
 
+use indexmap::IndexMap;
 use serde::de::{Error, Unexpected, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
@@ -207,8 +207,8 @@ pub struct Cmd {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub args: Vec<String>,
     #[serde(default)]
-    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
-    pub env: BTreeMap<EnvVar, Option<String>>,
+    #[serde(skip_serializing_if = "IndexMap::is_empty")]
+    pub env: IndexMap<EnvVar, Option<String>>,
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
@@ -225,10 +225,10 @@ pub struct Jump {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Boot {
-    pub commands: BTreeMap<String, Cmd>,
+    pub commands: IndexMap<String, Cmd>,
     #[serde(default)]
-    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
-    pub bindings: BTreeMap<String, Cmd>,
+    #[serde(skip_serializing_if = "IndexMap::is_empty")]
+    pub bindings: IndexMap<String, Cmd>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -296,7 +296,7 @@ impl Default for Fmt {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Other {
     #[serde(flatten)]
-    other: BTreeMap<String, Value>,
+    other: IndexMap<String, Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -358,7 +358,7 @@ impl Config {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use indexmap::IndexMap;
 
     use super::{ArchiveType, Boot, Cmd, Compression, Config, EnvVar, File, Jump, Lift};
     use crate::config::FileType;
@@ -432,7 +432,7 @@ mod tests {
                             }
                         )]
                         .into_iter()
-                        .collect::<BTreeMap<_, _>>(),
+                        .collect::<IndexMap<_, _>>(),
                         bindings: Default::default()
                     },
                     name: "test".to_string(),

--- a/jump/src/lib.rs
+++ b/jump/src/lib.rs
@@ -9,6 +9,7 @@ extern crate structure;
 
 mod archive;
 mod atomic;
+mod cmd_env;
 mod comparable_regex;
 pub mod config;
 mod context;


### PR DESCRIPTION
This is needed by https://github.com/a-scie/lift for interpreter group
selection support and is otherwise a reasonable thing to expect to have
worked.