### PR TITLE
Upgrade to Rust 1.70.0.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,3 @@
-[registries.crates-io]
-protocol = "sparse"
-
 [target.aarch64-pc-windows-msvc]
 rustflags = [
       # For Windows static msvcrt linking with no need for dll re-distribution.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
             docker run --rm \
               -v $PWD:/code \
               -w /code \
-              rust:1.69.0-alpine3.17 \
+              rust:1.70.0-alpine3.18 \
                 sh -c 'apk add musl-dev && cargo run -p package -- dist'
       - persist_to_workspace:
           root: dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           docker run --rm \
             -v $PWD:/code \
             -w /code \
-            rust:1.69.0-alpine3.17 \
+            rust:1.70.0-alpine3.18 \
               sh -c 'apk add musl-dev && cargo run -p package'
       - name: Integration Tests
         run: examples/run.sh --no-package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           docker run --rm \
             -v $PWD:/code \
             -w /code \
-            rust:1.69.0-alpine3.17 \
+            rust:1.70.0-alpine3.18 \
               sh -c 'apk add musl-dev && cargo run -p package -- dist'
       - name: Prepare Changelog
         id: prepare-changelog

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,7 +481,6 @@ dependencies = [
  "log",
  "logging_timer",
  "memmap",
- "once_cell",
  "parking_lot",
  "regex",
  "serde",

--- a/jump/Cargo.toml
+++ b/jump/Cargo.toml
@@ -37,5 +37,4 @@ walkdir = "2.3"
 [dev-dependencies]
 ctor = "0.2"
 env_logger = { workspace = true }
-once_cell = "1.17"
 parking_lot = "0.12"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,6 +1,6 @@
 [toolchain]
 # N.B.: Update .github and .circleci yaml to use a matching image.
-channel = "1.69.0"
+channel = "1.70.0"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
The release announcement is here:
  https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html

Since the sparse index protocol is now default, kill the explicit
configuration of that.

Also use the now stabilized std::sync::OnceLock instead of the once_cell
crate in tests.

Closes #108