### PR TITLE
Add support for scie base value placeholders.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## 0.12.0
+
+This release adds support for using placeholders in the `scie.lift.base` lift manifest value as well
+as the corresponding `SCIE_BASE` runtime control env var. A new placeholder is exposed in support of
+establishing custom scie base `nce` cache directories that respect the target OS user cache dir
+structure in the form of `{scie.user.cache_dir=<fallback>}`. Typically, this placeholder will expand
+to `~/Library/Caches` on macOS, `~\AppData\Local` on Windows and `~/.cache` on all other Unix
+systems unless over-ridden via OS-specific means or else unavailable for some reason, in which case
+the supplied `<fallback>` is used.
+
 ## 0.11.1
 
 This release fixes a bug handling environment variable removal via regex when the environment

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "jump"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "bstr",
  "byteorder",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "scie-jump"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "bstr",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 
 [package]
 name = "scie-jump"
-version = "0.11.1"
+version = "0.12.0"
 description = "The self contained interpreted executable launcher."
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -118,6 +118,10 @@ A scie "lift" can opt in to loading `.env` files via the "load_dotenv" boolean f
 https://crates.io/crates/dotenv) crate handles this loading. A lift's files and commands can also
 have additional configuration metadata described.
 
+A scie "lift" can also establish a custom `nce` cache directory via the "base" string field. Any
+placeholders  present in the custom value will be expanded save for the `{scie.lift}` placeholder
+which will lead to a scie jump boot error.
+
 For files, you can supply a "size" and sha256 "hash". Without these the boot-pack will calculate
 them, but you may want to set them in advance as a security precaution. The `scie-jump` will refuse
 to operate on any file whose size or hash do not match those specified. You can also manually
@@ -342,7 +346,9 @@ Runtime external control variables:
 + `SCIE_BOOT=<command>`: This can be used to select a non-default command for execution in a scie
   that defines named commands. One way to discover these is via invoking `SCIE=list <scie path>`.
 + `SCIE_BASE`: This can be used to override the default scie base of `~/.cache/nce` on Linux,
-   `~/Library/Caches/nce` on Mac and `~\AppData\Local\nce` on Windows.
+   `~/Library/Caches/nce` on Mac and `~\AppData\Local\nce` on Windows. Any placeholders save for
+   `{scie.lift}` will be expanded. If the `{scie.lift}` placeholder is encountered expanding the
+   `SCIE_BASE` value, a runtime error will abort the scie jump boot.
 
 Runtime read-only variables:
 
@@ -376,6 +382,7 @@ Further placeholders you can use in command "exe", "args" and "env" values inclu
   `linux`, `macos` or `windows` and `<ARCH>` is either `aarch64` or `x86_64`.
 + `{scie.platform.arch}`: The current chip architecture as described by `<ARCH>` above.
 + `{scie.platform.os}`: The current operating system as described by `<OS>` above.
++ `{scie.user.cache_dir=<fallback>}`: The default user cache dir or `<fallback>` if there is none.
 
 [^1]: The binaries that Coursier releases are single-file true native binaries that do not require a
 JVM at all. As such they are ~1/3 the size of the scie we build here, which contains a full JDK

--- a/jump/Cargo.toml
+++ b/jump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jump"
-version = "0.11.1"
+version = "0.12.0"
 description = "The bulk of the scie-jump binary logic."
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/jump/src/cmd_env.rs
+++ b/jump/src/cmd_env.rs
@@ -78,6 +78,9 @@ impl EnvParser {
                 Item::Placeholder(Placeholder::FileName(name)) => {
                     reified.push_str(&format!("{{scie.files.{name}}}"))
                 }
+                Item::Placeholder(Placeholder::UserCacheDir(fallback)) => {
+                    reified.push_str(&format!("{{scie.user.cache_dir={fallback}}}"))
+                }
                 Item::Placeholder(Placeholder::Scie) => reified.push_str("{scie}"),
                 Item::Placeholder(Placeholder::ScieBase) => reified.push_str("{scie.base}"),
                 Item::Placeholder(Placeholder::ScieBindings) => reified.push_str("{scie.bindings}"),
@@ -391,6 +394,27 @@ mod tests {
                 "{{scie.files.foo}}:{path}:{{scie}}:{{scie.base}}:{{scie.files.bar}}:baz{{}}",
                 path = env::var("PATH").unwrap()
             ),
+        )]
+        .into_iter()
+        .collect::<IndexMap<_, _>>();
+
+        assert_eq!(expected, env_parser.parse_env().unwrap());
+    }
+
+    #[test]
+    fn test_user_cache_dir_placeholder() {
+        let env_parser = EnvParser::new(
+            &[(
+                EnvVar::Replace("SCIE_BASE".to_string()),
+                Some("{scie.user.cache_dir=foo}".to_string()),
+            )]
+            .into_iter()
+            .collect::<IndexMap<_, _>>(),
+        );
+
+        let expected = [(
+            "SCIE_BASE".to_string(),
+            "{scie.user.cache_dir=foo}".to_string(),
         )]
         .into_iter()
         .collect::<IndexMap<_, _>>();

--- a/jump/src/config.rs
+++ b/jump/src/config.rs
@@ -3,7 +3,6 @@
 
 use std::fmt::Formatter;
 use std::io::Write;
-use std::path::PathBuf;
 
 use indexmap::IndexMap;
 use serde::de::{Error, Unexpected, Visitor};
@@ -240,7 +239,7 @@ pub struct Lift {
     pub description: Option<String>,
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub base: Option<PathBuf>,
+    pub base: Option<String>,
     pub files: Vec<File>,
     pub boot: Boot,
     #[serde(default)]

--- a/jump/src/installer.rs
+++ b/jump/src/installer.rs
@@ -164,6 +164,7 @@ where
     }
 }
 
+#[derive(Debug)]
 pub(crate) struct Installer<'a> {
     payload: &'a [u8],
 }

--- a/jump/src/lift.rs
+++ b/jump/src/lift.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 Science project contributors.
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use bstr::ByteSlice;
 use logging_timer::time;
@@ -52,7 +52,7 @@ impl From<File> for crate::config::File {
 pub struct Lift {
     pub name: String,
     pub description: Option<String>,
-    pub base: Option<PathBuf>,
+    pub base: Option<String>,
     pub(crate) load_dotenv: bool,
     pub size: usize,
     pub hash: String,


### PR DESCRIPTION
Both the lift manifest `scie.lift.base` field and the `SCIE_BASE` env
var now have their values expanded, accepting all placeholders except
for the `{scie.lift}` which depends on the fully evaluated value of the
scie base.

In order to make OS-convention-friendly values feasible, a new
`{scie.user.cache_dir=<fallback>}` placeholder is added that expands to
the OS-appropriate user cache dir when defined and `<fallback>` when
not.