### PR TITLE
Use maintained forks of dotenv(->y) & memmap(->2).

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,10 +260,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
+name = "dotenvy"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "either"
@@ -434,7 +434,7 @@ dependencies = [
  "bzip2",
  "ctor",
  "dirs",
- "dotenv",
+ "dotenvy",
  "env_logger",
  "fd-lock",
  "flate2",
@@ -442,7 +442,7 @@ dependencies = [
  "itertools",
  "log",
  "logging_timer",
- "memmap",
+ "memmap2",
  "parking_lot",
  "regex",
  "serde",
@@ -532,13 +532,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
-name = "memmap"
-version = "0.7.0"
+name = "memmap2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+checksum = "f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6"
 dependencies = [
  "libc",
- "winapi",
 ]
 
 [[package]]

--- a/jump/Cargo.toml
+++ b/jump/Cargo.toml
@@ -13,15 +13,15 @@ bstr = { workspace = true }
 byteorder = "1.4"
 bzip2 = "0.4"
 dirs = "4.0"
-dotenv = "0.15"
+dotenvy = "0.15"
 fd-lock = "3.0"
 flate2 = "1.0"  # For gz support.
 indexmap = { version = "1.9", features = ["serde"] }
 itertools = "0.10"
 log = { workspace = true }
 logging_timer = { workspace = true }
-memmap = "0.7"
-regex = { version = "1.7", default_features = false, features = ["std"] }
+memmap2 = "0.7"
+regex = { version = "1.7", default-features = false, features = ["std"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"

--- a/jump/src/lib.rs
+++ b/jump/src/lib.rs
@@ -119,7 +119,7 @@ pub fn prepare_boot() -> Result<BootAction, String> {
         )
     })?;
     let data = unsafe {
-        memmap::Mmap::map(&file)
+        memmap2::Mmap::map(&file)
             .map_err(|e| format!("Failed to mmap {exe}: {e}", exe = current_exe.exe.display()))?
     };
 
@@ -160,7 +160,7 @@ pub fn prepare_boot() -> Result<BootAction, String> {
 
     if lift.load_dotenv {
         let _timer = timer!(Level::Debug; "jump::load_dotenv");
-        if let Ok(dotenv_file) = dotenv::dotenv() {
+        if let Ok(dotenv_file) = dotenvy::dotenv() {
             debug!("Loaded env file from {path}", path = dotenv_file.display());
         }
     }


### PR DESCRIPTION
These 2 forks appear to be the blessed successors.

These unmaintained crate dependencies were revelead by a cargo audit run:
```
$ cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 570 security advisories (from /home/jsirois/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (140 crate dependencies)
Crate:     dotenv
Version:   0.15.0
Warning:   unmaintained
Title:     dotenv is Unmaintained
Date:      2021-12-24
ID:        RUSTSEC-2021-0141
URL:       https://rustsec.org/advisories/RUSTSEC-2021-0141
Dependency tree:
dotenv 0.15.0
└── jump 0.12.0
    ├── scie-jump 0.12.0
    └── package 0.2.0

Crate:     memmap
Version:   0.7.0
Warning:   unmaintained
Title:     memmap is unmaintained
Date:      2020-12-02
ID:        RUSTSEC-2020-0077
URL:       https://rustsec.org/advisories/RUSTSEC-2020-0077
Dependency tree:
memmap 0.7.0
└── jump 0.12.0
    ├── scie-jump 0.12.0
    └── package 0.2.0

warning: 2 allowed warnings found
```