### PR TITLE
Upgrade Rust to 1.72.1.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           docker run --rm \
             -v $PWD:/code \
             -w /code \
-            rust:1.72.0-alpine3.18 \
+            rust:1.72.1-alpine3.18 \
               sh -c 'apk add musl-dev && cargo run -p package'
       - name: Integration Tests
         run: examples/run.sh --no-package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           docker run --rm \
             -v $PWD:/code \
             -w /code \
-            rust:1.72.0-alpine3.18 \
+            rust:1.72.1-alpine3.18 \
               sh -c 'apk add musl-dev && cargo run -p package -- dist'
       - name: Prepare Changelog
         id: prepare-changelog

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,6 +1,6 @@
 [toolchain]
 # N.B.: Update .github and .circleci yaml to use a matching image.
-channel = "1.72.0"
+channel = "1.72.1"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
The release annoucement is here:
  https://blog.rust-lang.org/2023/09/19/Rust-1.72.1.html