### PR TITLE
Allow regex removal of non-utf8 env var names.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 0.13.1
+
+Support regex removal of env vars with non-utf8 names in commands.
+
 ## 0.13.0
 
 This release improves the help screen for BusyBox scies with more clear messages for the various

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "jump"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "bstr",
  "byteorder",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "scie-jump"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "bstr",
  "env_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,6 +452,7 @@ dependencies = [
  "log",
  "logging_timer",
  "memmap2",
+ "os_str_bytes",
  "parking_lot",
  "regex",
  "serde",
@@ -570,6 +580,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "package"
 version = "0.2.0"
 dependencies = [
@@ -685,24 +704,32 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
 dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.3.2"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d3daa6976cffb758ec878f108ba0e062a45b2d6ca3a2cca965338855476caf"
+checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 
 [package]
 name = "scie-jump"
-version = "0.13.0"
+version = "0.13.1"
 description = "The self contained interpreted executable launcher."
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -152,7 +152,9 @@ variable names will be removed. For example, `"BASH_.*": null` would remove all 
 variables whose name start with `BASH_` and `"=BASH_SOURCE": null` would just remove the
 `BASH_SOURCE` environment variable. When processing env entries, removals are done first, then
 defaults are set and finally overwrites are processed. This is regardless of the order of the env
-var entries in the lift manifest JSON document.
+var entries in the lift manifest JSON document. When evaluating environment variable removal regular
+expressions, the regular expression syntax is that supported by the Rust [`regex` crate](
+https://docs.rs/regex/latest/regex/).
 
 You can also supply a list of commands under "scie.lift.boot.bindings". These commands are objects
 with the same format as the "scie.lift.boot.commands" but they are not directly runnable by the end

--- a/jump/Cargo.toml
+++ b/jump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jump"
-version = "0.13.0"
+version = "0.13.1"
 description = "The bulk of the scie-jump binary logic."
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/jump/Cargo.toml
+++ b/jump/Cargo.toml
@@ -21,7 +21,8 @@ itertools = "0.10"
 log = { workspace = true }
 logging_timer = { workspace = true }
 memmap2 = "0.7"
-regex = { version = "1.7", default-features = false, features = ["std"] }
+os_str_bytes = "6.5"
+regex = { version = "1.9", default-features = false, features = ["std"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"

--- a/jump/src/comparable_regex.rs
+++ b/jump/src/comparable_regex.rs
@@ -6,7 +6,7 @@ use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 
-use regex::Regex;
+use regex::bytes::Regex;
 
 #[derive(Clone, Debug)]
 pub struct ComparableRegex(Regex);


### PR DESCRIPTION
Fixes #148