### PR TITLE
Require Cargo.lock matches Cargo.toml in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           rustup toolchain add nightly -c rustfmt
           cargo +nightly fmt --check --all
       - name: Lint
-        run: cargo clippy --all
+        run: cargo clippy --locked --all
       - name: Unit Tests
         run: cargo test --all
       - name: Build & Package


### PR DESCRIPTION
This passes `--locked` to the first interesting cargo invocation, to ensure that the `Cargo.lock` file is up to date with `Cargo.toml`. Without this,  if there's been changes to `Cargo.toml` and the user hasn't run a cargo command locally afterwards, the invocation might change the `Cargo.lock` file (e.g. bump versions, add packages) and thus CI runs with an unexpected configuration, that's not recorded in the repo.

(This came up in https://github.com/pantsbuild/scie-pants/pull/290 and I thought to check other Rust repos that are tangentially related.)