### PR TITLE
Upgrade to Rust 1.73.0.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
             docker run --rm \
               -v $PWD:/code \
               -w /code \
-              rust:1.72.0-alpine3.18 \
+              rust:1.72.1-alpine3.18 \
                 sh -c 'apk add musl-dev && cargo run -p package -- dist'
       - persist_to_workspace:
           root: dist

--- a/jump/src/comparable_regex.rs
+++ b/jump/src/comparable_regex.rs
@@ -35,7 +35,7 @@ impl Eq for ComparableRegex {}
 
 impl PartialOrd<Self> for ComparableRegex {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.0.as_str().partial_cmp(other.0.as_str())
+        Some(self.cmp(other))
     }
 }
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-# N.B.: Update .github and .circleci yaml to use a matching imagae, if available.
+# N.B.: Update .github and .circleci yaml to use a matching image, if available.
 # Although a version match is not required (cargo downloads and installs the
 # toolchain described here if not present), it does speed up CI builds.
 channel = "1.73.0"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,6 +1,8 @@
 [toolchain]
-# N.B.: Update .github and .circleci yaml to use a matching image.
-channel = "1.72.1"
+# N.B.: Update .github and .circleci yaml to use a matching imagae, if available.
+# Although a version match is not required (cargo downloads and installs the
+# toolchain described here if not present), it does speed up CI builds.
+channel = "1.73.0"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
The release announcement is here:
  https://blog.rust-lang.org/2023/10/05/Rust-1.73.0.html