### PR TITLE
Propagate errors loading `.env` files.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 0.13.2
+
+When `load_dotenv` is requested, propagate errors loading any `.env` file found.
+
 ## 0.13.1
 
 Support regex removal of env vars with non-utf8 names in commands.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "jump"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "bstr",
  "byteorder",
@@ -581,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.5.1"
+version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 dependencies = [
  "memchr",
 ]
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "scie-jump"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "bstr",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 
 [package]
 name = "scie-jump"
-version = "0.13.1"
+version = "0.13.2"
 description = "The self contained interpreted executable launcher."
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/examples/load/test.sh
+++ b/examples/load/test.sh
@@ -34,3 +34,12 @@ echo GET_CONFIG=alt-metadata.json > .env
 
 source .env
 grep "${GET_CONFIG}" "${GET_LOG_CONFIG}"
+
+# Motivated by: https://github.com/pantsbuild/scie-pants/issues/307
+# shellcheck disable=SC2016 # We with this text to be included verbatim in the .env file.
+echo 'PYTHONPATH="/foo/bar:$PYTHONPATH"' >> .env
+if ./cowsay "Should fail!"; then
+  die "The expected .env file loading failure did not happen."
+else
+  log "The expected .env file loading failure was successfully propagated."
+fi

--- a/jump/Cargo.toml
+++ b/jump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jump"
-version = "0.13.1"
+version = "0.13.2"
 description = "The bulk of the scie-jump binary logic."
 authors = [
     "John Sirois <john.sirois@gmail.com>",
@@ -21,7 +21,7 @@ itertools = "0.10"
 log = { workspace = true }
 logging_timer = { workspace = true }
 memmap2 = "0.7"
-os_str_bytes = "6.5"
+os_str_bytes = { version = "6.6", features = ["conversions"] }
 regex = { version = "1.9", default-features = false, features = ["std"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/jump/src/lib.rs
+++ b/jump/src/lib.rs
@@ -189,9 +189,11 @@ pub fn prepare_boot() -> Result<BootAction, String> {
                     cwd = env::current_dir()
                 )
             }
-            Err(err) => return Err(format!(
+            Err(err) => {
+                return Err(format!(
                 "This scie requested .env files be loaded but there was an error doing so: {err}"
-            )),
+            ))
+            }
         }
     }
     let payload = &data[jump.size..data.len() - lift.size];

--- a/jump/src/lib.rs
+++ b/jump/src/lib.rs
@@ -180,8 +180,18 @@ pub fn prepare_boot() -> Result<BootAction, String> {
 
     if lift.load_dotenv {
         let _timer = timer!(Level::Debug; "jump::load_dotenv");
-        if let Ok(dotenv_file) = dotenvy::dotenv() {
-            debug!("Loaded env file from {path}", path = dotenv_file.display());
+        match dotenvy::dotenv() {
+            Ok(dotenv_file) => debug!("Loaded env file from {path}", path = dotenv_file.display()),
+            Err(err) if err.not_found() => {
+                debug!(
+                    "No .env files found for invocation of {current_exe} from cwd of {cwd:?}",
+                    current_exe = current_exe.exe.display(),
+                    cwd = env::current_dir()
+                )
+            }
+            Err(err) => return Err(format!(
+                "This scie requested .env files be loaded but there was an error doing so: {err}"
+            )),
         }
     }
     let payload = &data[jump.size..data.len() - lift.size];


### PR DESCRIPTION
Previously, when requesting `load_dotenv` for a scie, the scie would
silently skip all `.env` file lines after any line with a syntax error.

Fixes #163