### PR TITLE
Fix our xz2 crate configuration to enable static linking.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,10 +26,12 @@ jobs:
     resource_class: arm.medium
     steps:
       - checkout
-      - rust/install:
-          version: nightly
-      - rust/format:
-          nightly-toolchain: true
+      # TODO(John Sirois): https://github.com/a-scie/jump/issues/174
+      #  Undo once https://github.com/rust-lang/rustfmt/issues/5964 is fixed.
+      #- rust/install:
+      #    version: nightly
+      #- rust/format:
+      #    nightly-toolchain: true
       - rust/install
       - rust/clippy
       - rust/test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Check Formatting
+        # TODO(John Sirois): https://github.com/a-scie/jump/issues/174
+        #  Undo once https://github.com/rust-lang/rustfmt/issues/5964 is fixed.
+        if: matrix.os != 'macos-13-aarch64'
         run: |
           rustup toolchain add nightly -c rustfmt
           cargo +nightly fmt --check --all

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 0.13.3
+
+Ensure liblzma is statically linked.
+
 ## 0.13.2
 
 When `load_dotenv` is requested, propagate errors loading any `.env` file found.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "jump"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "bstr",
  "byteorder",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "scie-jump"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "bstr",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 
 [package]
 name = "scie-jump"
-version = "0.13.2"
+version = "0.13.3"
 description = "The self contained interpreted executable launcher."
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/jump/Cargo.toml
+++ b/jump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jump"
-version = "0.13.2"
+version = "0.13.3"
 description = "The bulk of the scie-jump binary logic."
 authors = [
     "John Sirois <john.sirois@gmail.com>",
@@ -30,7 +30,7 @@ structure = "0.1"
 tar = "0.4"
 tempfile = { workspace = true }
 tuple = "0.5"
-xz2 = "0.1"
+xz2 = { version = "0.1", features = ["static"] }
 zip = { workspace = true }
 zstd = "0.12"
 walkdir = "2.3"


### PR DESCRIPTION
Previously liblzma was dynamically linked (to a homebrew version).

Fixes #172