### PR TITLE
Undo aarch64 rustfmt skips.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,12 +26,10 @@ jobs:
     resource_class: arm.medium
     steps:
       - checkout
-      # TODO(John Sirois): https://github.com/a-scie/jump/issues/174
-      #  Undo once https://github.com/rust-lang/rustfmt/issues/5964 is fixed.
-      #- rust/install:
-      #    version: nightly
-      #- rust/format:
-      #    nightly-toolchain: true
+      - rust/install:
+          version: nightly
+      - rust/format:
+          nightly-toolchain: true
       - rust/install
       - rust/clippy
       - rust/test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Check Formatting
-        # TODO(John Sirois): https://github.com/a-scie/jump/issues/174
-        #  Undo once https://github.com/rust-lang/rustfmt/issues/5964 is fixed.
-        if: matrix.os != 'macos-13-aarch64'
         run: |
           rustup toolchain add nightly -c rustfmt
           cargo +nightly fmt --check --all


### PR DESCRIPTION
These skips were added in #173 to work around this issue:
  https://github.com/rust-lang/rustfmt/issues/5964

It has been resolved; so formatting should now work on all architectures.

Fixes #174