### PR TITLE
Add support for expanding `.env` quoted values.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.14.0
+
+Change `.env` parsing libraries to gain support for double quoted values with variable
+substitution; e.g.: the `.env` line `PYTHONPATH="/Users/A. Space:$PYTHONPATH"` now has the
+`$PYTHONPATH` portion of the value substituted.
+
 ## 0.13.3
 
 Ensure liblzma is statically linked.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,10 +269,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "dotenvy"
-version = "0.15.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+name = "dotenvs"
+version = "0.1.0"
+source = "git+https://github.com/jsirois/dotenvs-rs?rev=b2276ef3fd039ed8565b4c1cbedb7a5aeeca734e#b2276ef3fd039ed8565b4c1cbedb7a5aeeca734e"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "either"
@@ -436,14 +438,14 @@ dependencies = [
 
 [[package]]
 name = "jump"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "bstr",
  "byteorder",
  "bzip2",
  "ctor",
  "dirs",
- "dotenvy",
+ "dotenvs",
  "env_logger",
  "fd-lock",
  "flate2",
@@ -551,6 +553,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,6 +576,16 @@ dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -781,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "scie-jump"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "bstr",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 
 [package]
 name = "scie-jump"
-version = "0.13.3"
+version = "0.14.0"
 description = "The self contained interpreted executable launcher."
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -114,9 +114,31 @@ In the "lift" manifest, there are 3 required fields:
 
 ### Optional fields
 
-A scie "lift" can opt in to loading `.env` files via the "load_dotenv" boolean field. The [dotenv](
-https://crates.io/crates/dotenv) crate handles this loading. A lift's files and commands can also
-have additional configuration metadata described.
+A scie "lift" can opt in to loading `.env` files via the "load_dotenv" boolean field. The [dotenvs](
+https://crates.io/crates/dotenvs) crate handles this loading and the following behavior is
+guaranteed:
+
+Parsing rules:
+
+- `BASIC=basic` and `export BASIC=basic` both export an environment variable named `BASIC` with
+  value `basic`.
+- Empty lines are skipped.
+- Lines beginning with `#` are treated as comments.
+- A `#` marks the beginning of a comment (unless the value is wrapped in quotes).
+- Empty values become empty strings.
+- Inner quotes are maintained.
+- Whitespace is removed from both ends of unquoted values.
+- Single and double quoted values maintain whitespace from both ends.
+
+Expanding rules:
+
+- `$KEY` or `${KEY}` will expand to the ambient environment value of `KEY` (unless the value is
+  wrapped in single quotes). If there is no ambient environment value for `KEY`, the expanded value
+  will be an empty string.
+- `${KEY:-default}` will first attempt to expand `KEY` subject to the rules above. If `KEY` is not
+  defined, then it will return `default`.
+- `\$KEY` will escape the `$KEY` rather than expand when not wrapped with quotes or wrapped with
+  double quotes.
 
 A scie "lift" can also establish a custom `nce` cache directory via the "base" string field. Any
 placeholders  present in the custom value will be expanded save for the `{scie.lift}` placeholder

--- a/examples/load/test.sh
+++ b/examples/load/test.sh
@@ -36,8 +36,20 @@ source .env
 grep "${GET_CONFIG}" "${GET_LOG_CONFIG}"
 
 # Motivated by: https://github.com/pantsbuild/scie-pants/issues/307
+# And ammended by: https://github.com/a-scie/jump/issues/166
 # shellcheck disable=SC2016 # We with this text to be included verbatim in the .env file.
 echo 'PYTHONPATH="/foo/bar:$PYTHONPATH"' >> .env
+./cowsay "Should succeed!"
+
+# See motivating case here: https://github.com/arniu/dotenvs-rs/issues/4
+cat << EOF >> .env
+A=foo bar
+B="notenough
+C='toomany''
+D=valid
+export NOT_SET
+E=valid
+EOF
 if ./cowsay "Should fail!"; then
   die "The expected .env file loading failure did not happen."
 else

--- a/jump/Cargo.toml
+++ b/jump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jump"
-version = "0.13.3"
+version = "0.14.0"
 description = "The bulk of the scie-jump binary logic."
 authors = [
     "John Sirois <john.sirois@gmail.com>",
@@ -13,7 +13,6 @@ bstr = { workspace = true }
 byteorder = "1.4"
 bzip2 = "0.4"
 dirs = "4.0"
-dotenvy = "0.15"
 fd-lock = "3.0"
 flate2 = "1.0"  # For gz support.
 indexmap = { version = "1.9", features = ["serde"] }
@@ -34,6 +33,10 @@ xz2 = { version = "0.1", features = ["static"] }
 zip = { workspace = true }
 zstd = "0.12"
 walkdir = "2.3"
+
+[dependencies.dotenvs]
+git = "https://github.com/jsirois/dotenvs-rs"
+rev = "b2276ef3fd039ed8565b4c1cbedb7a5aeeca734e"
 
 [dev-dependencies]
 ctor = "0.2"


### PR DESCRIPTION
Switch from the dotenvy crate to dotenvs to achieve this. A patched
version is used to ensure we maintain support for hard failure when
invalid `.env` files are read.

Fixes #166
Fixes #167