### PR TITLE
Fix `boot-pack` help.

### DIFF
--- a/jump/src/lib.rs
+++ b/jump/src/lib.rs
@@ -56,10 +56,10 @@ boot-pack
     Pack the given lift manifests into scie executables. If no manifests
     are given, looks for `lift.json` in the current directory. By
     default the current scie-jump is used as the scie tip, but an
-    alternate scie-jump binary can be specified using --path. By default
-    the lift manifest is appended to the tail of the scie as a single
-    line JSON document, but can be made a multi-line pretty-printed JSON
-    document by passing --no-single-lift-line.
+    alternate scie-jump binary can be specified using --scie-jump. By
+    default the lift manifest is appended to the tail of the scie as a
+    single line JSON document, but can be made a multi-line
+    pretty-printed JSON document by passing --no-single-lift-line.
 
 help: Display this help message.
 


### PR DESCRIPTION
The reference to `--path` was in error, it should have been
`-sj|--jump|--scie-jump`.