### PR TITLE
Stabilize cargo audit.

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -12,5 +12,5 @@ jobs:
         uses: actions/checkout@v4
       - name: Cargo audit (for security vulnerabilities)
         run: |
-          cargo install --version 0.18.1 cargo-audit
+          cargo install --locked cargo-audit
           cargo audit


### PR DESCRIPTION
The previous incantation both kept cargo-audit back and did not use its
lock. This was the worst of both worlds and led to an audit job break.