### PR TITLE
Upgrade to jobserver with musl libc support.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,9 +434,9 @@ checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "jobserver"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+checksum = "685a7d121ee3f65ae4fddd72b25a04bb36b6af81bc0828f7d5434c0fe60fa3a2"
 dependencies = [
  "libc",
 ]
@@ -800,7 +800,6 @@ version = "0.14.0"
 dependencies = [
  "bstr",
  "env_logger",
- "jobserver",
  "jump",
  "log",
  "logging_timer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,14 +38,6 @@ features = ["deflate"]
 [dependencies]
 bstr = { workspace = true }
 env_logger = { workspace = true }
-
-# The 0.1.29 release adds dependencies on libc preadv2 which are not available in musl until
-# 1.2.5 which our alpine image does not have access to yet; so we pin this transitive dependency
-# low here.
-# TODO(John Sirois): Remove this dependency once we can upgrade to an image with musl support for
-# newer jobserver.
-jobserver = "<0.1.29"
-
 jump = { path = "jump" }
 log = { workspace = true }
 logging_timer = { workspace = true }


### PR DESCRIPTION
The 0.1.29 release broke musl libc support and 0.1.30 restores it: https://github.com/rust-lang/jobserver-rs/compare/43e36bb47c101ccc2553aea8a07694d985438fa6...4ac8212169e06f427ccd4da985cf023a483fc6a6

Remove our explicit pin low dep and run `cargo update -p jobserver` to pick up the fix.