### PR TITLE
Upgrade Rust to 1.78.0.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
             docker run --rm \
               -v $PWD:/code \
               -w /code \
-              rust:1.77.2-alpine3.19 \
+              rust:1.78.0-alpine3.19 \
                 sh -c 'apk add musl-dev && cargo run -p package -- dist'
       - persist_to_workspace:
           root: dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           docker run --rm \
             -v $PWD:/code \
             -w /code \
-            rust:1.77.2-alpine3.19 \
+            rust:1.78.0-alpine3.19 \
               sh -c 'apk add musl-dev && cargo run -p package'
       - name: Integration Tests
         run: examples/run.sh --no-package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
           docker run --rm \
             -v $PWD:/code \
             -w /code \
-            rust:1.77.2-alpine3.19 \
+            rust:1.78.0-alpine3.19 \
               sh -c 'apk add musl-dev && cargo run -p package -- dist'
       - name: Prepare Changelog
         id: prepare-changelog

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 1.0.0
+
+This release updates various dependencies as well as upgrading to Rust
+1.78.0 and dropping support for Windows versions prior to Windows 10.
+
 ## 0.14.0
 
 Change `.env` parsing libraries to gain support for double quoted values with variable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "scie-jump"
-version = "0.14.0"
+version = "1.0.0"
 dependencies = [
  "bstr",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 
 [package]
 name = "scie-jump"
-version = "0.14.0"
+version = "1.0.0"
 description = "The self contained interpreted executable launcher."
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -2,7 +2,7 @@
 # N.B.: Update .github and .circleci yaml to use a matching image, if available.
 # Although a version match is not required (cargo downloads and installs the
 # toolchain described here if not present), it does speed up CI builds.
-channel = "1.77.2"
+channel = "1.78.0"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
The 1.78 release bumps the minimum supported Windows version to Windows
10; so we bump our major version to indicate the breaking change, and,
~1.5 years after the first public release, semi-offcially declare
stability given some level of battle testing.

As a point of reference, Microsoft support for Windows 8 ended on
January 12, 2016, and support for Windows 8.1 ended on
January 10, 2023; so `scie-jump` likely only ever could have had
Windows 8.1 users.

The release announcement is here:
  https://blog.rust-lang.org/2024/05/02/Rust-1.78.0.html