### PR TITLE
Revert "Bump bstr from 1.9.1 to 1.10.0"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.10.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
+checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
 dependencies = [
  "memchr",
  "regex-automata 0.4.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ lto = "fat"
 codegen-units = 1
 
 [workspace.dependencies]
-bstr = "1.10"
+bstr = "1.9"
 env_logger = { version = "0.10", default-features = false }
 log = "0.4"
 logging_timer = "1.1"


### PR DESCRIPTION
Reverts a-scie/jump#228

[target.aarch64-pc-windows-msvc]
rustflags = [
    "-C", "target-feature=+crt-static", # Static CRT for 64-bit ARM Windows
    "-C", "link-arg=/NODEFAULTLIB:libcmt" # Avoid automatic dynamic CRT linking
]

[target.x86_64-pc-windows-msvc]
rustflags = [
    "-C", "target-feature=+crt-static", # Static CRT for 64-bit x86 Windows
    "-C", "link-arg=/NODEFAULTLIB:libcmt" # Avoid automatic dynamic CRT linking
]
