### PR TITLE
Add a Windows ARM64 release.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         # N.B.: macos-12 is the oldest non-deprecated Intel Mac runner and macos-14 is the oldest
         # non-deprecated ARM Mac runner.
-        os: [ubuntu-22.04, linux-arm64, macos-12, macos-14, windows-2022]
+        os: [ ubuntu-22.04, linux-arm64, macos-12, macos-14, windows-2022, windows-arm64 ]
     steps:
       - uses: actions/checkout@v4
       - name: Check Formatting

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         # N.B.: macos-12 is the oldest non-deprecated Intel Mac runner and macos-14 is the oldest
         # non-deprecated ARM Mac runner.
-        os: [ ubuntu-22.04, linux-arm64, macos-12, macos-14, windows-2022 ]
+        os: [ ubuntu-22.04, linux-arm64, macos-12, macos-14, windows-2022, windows-arm64 ]
     environment: Release
     permissions:
       id-token: write
@@ -85,7 +85,7 @@ jobs:
         with:
           changelog-file: ${{ github.workspace }}/CHANGES.md
           version: ${{ needs.determine-tag.outputs.release-version }}
-          setup-python: ${{ matrix.os != 'linux-arm64' }}
+          setup-python: ${{ matrix.os != 'linux-arm64' && matrix.os != 'windows-arm64' }}
       - name: Create ${{ needs.determine-tag.outputs.release-tag }} Release
         uses: softprops/action-gh-release@v2
         with:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 1.2.0
+
+This release adds support for Windows ARM64.
+
 ## 1.1.1
 
 This release fixes missing attestations for Linux ARM64 artifacts.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "scie-jump"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "bstr",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 
 [package]
 name = "scie-jump"
-version = "1.1.1"
+version = "1.2.0"
 description = "The self contained interpreted executable launcher."
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/examples/cat/lift.windows-aarch64.json
+++ b/examples/cat/lift.windows-aarch64.json
@@ -1,0 +1,42 @@
+{
+  "scie": {
+    "lift": {
+      "name": "java",
+      "files": [
+        {
+          "name": "openjdk-19.0.1_windows-x64_bin.zip",
+          "key": "jdk",
+          "size": 194441800,
+          "hash": "adb1a33c07b45c39b926bdeeadf800f701be9c3d04e0deb543069e5f09856185",
+          "type": "zip"
+        },
+        {
+          "name": "cowsay-1.1.0.jar",
+          "key": "cowsay.jar",
+          "size": 1724250,
+          "hash": "212ee64546eb8b5074572fed4107d850eb90bc462aa3099c0ac8ea63fdca7811",
+          "type": "blob"
+        }
+      ],
+      "boot": {
+        "commands": {
+          "": {
+            "exe": "{jdk}/jdk-19.0.1/bin/java",
+            "args": [
+              "-jar",
+              "{cowsay.jar}"
+            ],
+            "env": {
+              "=JAVA_HOME": "{jdk}/jdk-19.0.1",
+              "=PATH": "{jdk}/jdk-19.0.1/bin:{scie.env.PATH}"
+            }
+          }
+        }
+      }
+    },
+    "jump": null
+  },
+  "fetch": [
+    "https://download.java.net/java/GA/jdk19.0.1/afdd2e245b014143b62ccb916125e3ce/10/GPL/openjdk-19.0.1_windows-x64_bin.zip"
+  ]
+}

--- a/examples/java/lift.windows-aarch64.json
+++ b/examples/java/lift.windows-aarch64.json
@@ -1,0 +1,38 @@
+{
+  "scie": {
+    "lift": {
+      "name": "coursier",
+      "boot": {
+        "commands": {
+          "": {
+            "env": {
+              "=JAVA_HOME": "{jdk}/jdk11.0.17_8",
+              "=PATH": "{jdk}/jdk11.0.17_8/bin:{scie.env.PATH}"
+            },
+            "exe": "{jdk}/jdk11.0.17_8/bin/java",
+            "args": [
+              "-jar",
+              "{coursier.jar}"
+            ]
+          }
+        }
+      },
+      "files": [
+        {
+          "name": "amazon-corretto-11.0.17.8.1-windows-x64-jdk.zip",
+          "key": "jdk"
+        },
+        {
+          "name": "coursier.jar"
+        }
+      ]
+    }
+  },
+  "fetch": [
+    "https://corretto.aws/downloads/resources/11.0.17.8.1/amazon-corretto-11.0.17.8.1-windows-x64-jdk.zip"
+  ],
+  "custom": {
+    "arbitrary": 3
+  },
+  "more": ["and", "more"]
+}

--- a/examples/load/lift.windows-aarch64.json
+++ b/examples/load/lift.windows-aarch64.json
@@ -1,0 +1,57 @@
+{
+  "scie": {
+    "lift": {
+      "name": "cowsay",
+      "load_dotenv": true,
+      "files": [
+        {
+          "name": "get.sh"
+        },
+        {
+          "name": "cowsay-1.1.0.jar",
+          "key": "cowsay.jar",
+          "size": 1724250,
+          "hash": "212ee64546eb8b5074572fed4107d850eb90bc462aa3099c0ac8ea63fdca7811",
+          "type": "blob",
+          "source": "get"
+        },
+        {
+          "name": "openjdk-19.0.1_windows-x64_bin.zip",
+          "key": "jdk",
+          "size": 194441800,
+          "hash": "adb1a33c07b45c39b926bdeeadf800f701be9c3d04e0deb543069e5f09856185",
+          "type": "zip",
+          "source": "get"
+        }
+      ],
+      "boot": {
+        "commands": {
+          "": {
+            "exe": "{jdk}/jdk-19.0.1/bin/java",
+            "args": [
+              "-jar",
+              "{cowsay.jar}"
+            ],
+            "env": {
+              "=JAVA_HOME": "{jdk}/jdk-19.0.1",
+              "=PATH": "{jdk}/jdk-19.0.1/bin:{scie.env.PATH}"
+            }
+          }
+        },
+        "bindings": {
+          "get": {
+            "exe": "C:\\Program Files\\Git\\usr\\bin\\bash",
+            "args": [
+              "{get.sh}",
+              "{scie.env.GET_CONFIG={scie.lift}}"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "get": {
+    "openjdk-19.0.1_windows-x64_bin.zip": "https://download.java.net/java/GA/jdk19.0.1/afdd2e245b014143b62ccb916125e3ce/10/GPL/openjdk-19.0.1_windows-x64_bin.zip",
+    "cowsay-1.1.0.jar": "https://repo1.maven.org/maven2/com/github/ricksbrown/cowsay/1.1.0/cowsay-1.1.0.jar"
+  }
+}

--- a/examples/node/cowsay-lift.windows-aarch64.json
+++ b/examples/node/cowsay-lift.windows-aarch64.json
@@ -1,0 +1,30 @@
+{
+  "scie": {
+    "lift": {
+      "name": "cowsay.js",
+      "boot": {
+        "commands": {
+          "": {
+            "env": {
+              "NODE_PATH": "{node_modules}",
+              "=PATH": "{node}/node-v18.12.0-win-x64:{scie.env.PATH}"
+            },
+            "exe": "{node}/node-v18.12.0-win-x64/node.exe",
+            "args": [
+              "{node_modules}/cowsay/cli.js"
+            ]
+          }
+        }
+      },
+      "files": [
+        {
+          "name": "node-v18.12.0-win-x64.zip",
+          "key": "node"
+        },
+        {
+          "name": "node_modules"
+        }
+      ]
+    }
+  }
+}

--- a/examples/node/lift.windows-aarch64.json
+++ b/examples/node/lift.windows-aarch64.json
@@ -1,0 +1,32 @@
+{
+  "scie": {
+    "lift": {
+      "name": "node.js",
+      "boot": {
+        "commands": {
+          "node": {
+            "env": {
+              "=PATH": "{node}/node-v18.12.0-win-x64:{scie.env.PATH}"
+            },
+            "exe": "{node}/node-v18.12.0-win-x64/node.exe"
+          },
+          "npm": {
+            "env": {
+              "=PATH": "{node}/node-v18.12.0-win-x64/bin:{scie.env.PATH}"
+            },
+            "exe": "{node}/node-v18.12.0-win-x64/npm.cmd"
+          }
+        }
+      },
+      "files": [
+        {
+          "name": "node-v18.12.0-win-x64.zip",
+          "key": "node"
+        }
+      ]
+    }
+  },
+  "fetch": [
+    "https://nodejs.org/dist/v18.12.0/node-v18.12.0-win-x64.zip"
+  ]
+}

--- a/examples/ptex/lift.windows-aarch64.json
+++ b/examples/ptex/lift.windows-aarch64.json
@@ -1,0 +1,59 @@
+{
+  "scie": {
+    "lift": {
+      "name": "cowsay",
+      "files": [
+        {
+          "name": "ptex-windows-x86_64.exe",
+          "key": "ptex"
+        },
+        {
+          "name": "cowsay-1.1.0.jar",
+          "key": "cowsay.jar",
+          "size": 1724250,
+          "hash": "212ee64546eb8b5074572fed4107d850eb90bc462aa3099c0ac8ea63fdca7811",
+          "type": "blob",
+          "source": "ptex-fetch"
+        },
+        {
+          "name": "openjdk-19.0.1_windows-x64_bin.zip",
+          "key": "jdk",
+          "size": 194441800,
+          "hash": "adb1a33c07b45c39b926bdeeadf800f701be9c3d04e0deb543069e5f09856185",
+          "type": "zip",
+          "source": "ptex-fetch"
+        }
+      ],
+      "boot": {
+        "commands": {
+          "": {
+            "exe": "{jdk}/jdk-19.0.1/bin/java",
+            "args": [
+              "-jar",
+              "{cowsay.jar}"
+            ],
+            "env": {
+              "=JAVA_HOME": "{jdk}/jdk-19.0.1",
+              "=PATH": "{jdk}/jdk-19.0.1/bin:{scie.env.PATH}"
+            }
+          }
+        },
+        "bindings": {
+          "ptex-fetch": {
+            "exe": "{ptex}",
+            "args": [
+              "{scie.lift}"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "fetch": [
+    "https://github.com/a-scie/ptex/releases/download/v0.2.0/ptex-windows-x86_64.exe"
+  ],
+  "ptex": {
+    "openjdk-19.0.1_windows-x64_bin.zip": "https://download.java.net/java/GA/jdk19.0.1/afdd2e245b014143b62ccb916125e3ce/10/GPL/openjdk-19.0.1_windows-x64_bin.zip",
+    "cowsay-1.1.0.jar": "https://repo1.maven.org/maven2/com/github/ricksbrown/cowsay/1.1.0/cowsay-1.1.0.jar"
+  }
+}

--- a/examples/run.sh
+++ b/examples/run.sh
@@ -43,7 +43,7 @@ function calculate_arch() {
     arch="$(uname -m)"
   fi
 
-  if [[ "${arch}" =~ x86[_-]64 ]]; then
+  if [[ "${arch}" =~ amd64|x86[_-]64 ]]; then
     echo x86_64
   elif [[ "${arch}" =~ arm64|aarch64 ]]; then
     echo aarch64

--- a/examples/run.sh
+++ b/examples/run.sh
@@ -38,14 +38,14 @@ function calculate_arch() {
   local arch
 
   if [[ "windows" == "$1" ]]; then
-    arch="$(pwsh -c '$Env:PROCESSOR_ARCHITECTURE')"
+    arch="$(pwsh -c '$Env:PROCESSOR_ARCHITECTURE.ToLower()')"
   else
     arch="$(uname -m)"
   fi
 
-  if [[ "${arch,,}" =~ x86[_-]64 ]]; then
-      echo x86_64
-  elif [[ "${arch,,}" =~ arm64|aarch64 ]]; then
+  if [[ "${arch}" =~ x86[_-]64 ]]; then
+    echo x86_64
+  elif [[ "${arch}" =~ arm64|aarch64 ]]; then
     echo aarch64
   else
     die "Integration tests are not supported for this chip architecture (${arch})."

--- a/examples/run.sh
+++ b/examples/run.sh
@@ -37,10 +37,15 @@ function calculate_os() {
 function calculate_arch() {
   local arch
 
-  arch="$(uname -m)"
-  if [[ "${arch}" =~ x86[_-]64 ]]; then
-    echo x86_64
-  elif [[ "${arch}" =~ arm64|aarch64 ]]; then
+  if [[ "windows" == "$1" ]]; then
+    arch="$(pwsh -c '$Env:PROCESSOR_ARCHITECTURE')"
+  else
+    arch="$(uname -m)"
+  fi
+
+  if [[ "${arch,,}" =~ x86[_-]64 ]]; then
+      echo x86_64
+  elif [[ "${arch,,}" =~ arm64|aarch64 ]]; then
     echo aarch64
   else
     die "Integration tests are not supported for this chip architecture (${arch})."
@@ -122,7 +127,7 @@ for arg in "$@"; do
   fi
 done
 
-ARCH="$(calculate_arch)"
+ARCH="$(calculate_arch "${OS}")"
 OS_ARCH="${OS}-${ARCH}"
 LIFT="lift.${OS_ARCH}.json"
 DIST_DIR="${REPO_ROOT}/dist"


### PR DESCRIPTION
Fixup arch detection in `examples/run.sh` to handle Git for Windows
(and thus bash, etc.) being x86-64 still: use PowerShell to determine
the true arch.