### PR TITLE
Upgrade to Rust 1.82.0.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           docker run --rm \
             -v $PWD:/code \
             -w /code \
-            rust:1.81.0-alpine3.20 \
+            rust:1.82.0-alpine3.20 \
               sh -c "
                 apk add musl-dev &&
                 addgroup -g $(id -g) build &&

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
           docker run --rm \
             -v $PWD:/code \
             -w /code \
-            rust:1.81.0-alpine3.20 \
+            rust:1.82.0-alpine3.20 \
               sh -c "
                 apk add musl-dev &&
                 addgroup -g $(id -g) build &&

--- a/jump/src/context.rs
+++ b/jump/src/context.rs
@@ -111,6 +111,8 @@ impl Debug for LoadProcess {
     }
 }
 
+// The two largest variants are Install at ~136 bytes and LoadAndInstall at ~616 bytes.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub(crate) enum FileEntry {
     Skip(usize),

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -2,7 +2,7 @@
 # N.B.: Update .github and .circleci yaml to use a matching image, if available.
 # Although a version match is not required (cargo downloads and installs the
 # toolchain described here if not present), it does speed up CI builds.
-channel = "1.81.0"
+channel = "1.82.0"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
The release announcement is here:
  https://blog.rust-lang.org/2024/10/17/Rust-1.82.0.html