### PR TITLE
Upgrade to Rust 1.84.0.

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.83.0"
+channel = "1.84.0"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
Announcement: https://blog.rust-lang.org/2025/01/09/Rust-1.84.0.html