### PR TITLE
Upgrade to Rust 1.85.0 / 2024 edition.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.2.1"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990a40740adf249724a6000c0fc4bd574712f50bb17c2d6f6cec837ae2f0ee75"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote 1.0.28",
  "syn 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "The self contained interpreted executable launcher."
 authors = [
     "John Sirois <john.sirois@gmail.com>",
 ]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [profile.release]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.84.1"
+channel = "1.85.0"
 components = [
   "cargo",
   "clippy",

--- a/src/boot/pack.rs
+++ b/src/boot/pack.rs
@@ -6,7 +6,7 @@ use std::io::{Read, Seek};
 use std::path::{Path, PathBuf};
 
 use jump::config::{ArchiveType, FileType, Fmt};
-use jump::{check_is_zip, create_options, fingerprint, load_lift, File, Jump, Lift, Source};
+use jump::{File, Jump, Lift, Source, check_is_zip, create_options, fingerprint, load_lift};
 use logging_timer::time;
 use proc_exit::{Code, ExitResult};
 use zip::{CompressionMethod, ZipWriter};


### PR DESCRIPTION
Announcement: https://blog.rust-lang.org/2025/02/20/Rust-1.85.0.html

Also `cargo update -p ctor` to get past the warning detailed here:
  https://github.com/mmastrac/rust-ctor/issues/309