### PR TITLE
Provide help for the bare `scie-jump`.

### DIFF
--- a/jump/src/jump.rs
+++ b/jump/src/jump.rs
@@ -7,11 +7,10 @@ use std::path::Path;
 use byteorder::{LittleEndian, ReadBytesExt};
 
 pub const EOF_MAGIC: u32 = 0x534a7219;
-pub(crate) const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 use crate::config::Jump;
 
-pub fn load(data: &[u8], path: &Path) -> Result<Option<Jump>, String> {
+pub fn load(scie_jump_version: &str, data: &[u8], path: &Path) -> Result<Option<Jump>, String> {
     let mut magic = Cursor::new(&data[data.len() - 8..]);
     magic.seek(SeekFrom::End(-4)).map_err(|e| format!("{e}"))?;
     if let Ok(EOF_MAGIC) = magic.read_u32::<LittleEndian>() {
@@ -38,7 +37,7 @@ pub fn load(data: &[u8], path: &Path) -> Result<Option<Jump>, String> {
             ));
         }
         return Ok(Some(Jump {
-            version: VERSION.to_string(),
+            version: scie_jump_version.to_string(),
             size: size as usize,
         }));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,10 +51,12 @@ fn exec(exe: OsString, args: Vec<OsString>, argv_skip: usize) -> ExitResult {
         .map(|_| ())
 }
 
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 fn main() -> ExitResult {
     env_logger::init();
 
-    let action = jump::prepare_boot().map_err(|e| {
+    let action = jump::prepare_boot(VERSION).map_err(|e| {
         Code::FAILURE.with_message(format!("Failed to prepare a scie jump action: {e}"))
     })?;
 


### PR DESCRIPTION
There is now a `-h` / `--help` option as well as a default action of
printing help when no CWD-local lift.json manifest is found.

Also support `-V` / `--version` and fix the scie-jump version reported
in the lift manifest to be the `scie-jump` binary version and not the
jump crate version.