### PR TITLE
Upgrade rust to 1.85.1 / jump to 2025 edition.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,7 +541,6 @@ dependencies = [
  "logging_timer",
  "memmap2",
  "os_str_bytes",
- "parking_lot",
  "regex",
  "serde",
  "serde_json",
@@ -579,16 +578,6 @@ name = "linux-raw-sys"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9"
-
-[[package]]
-name = "lock_api"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
 
 [[package]]
 name = "lockfree-object-pool"
@@ -721,29 +710,6 @@ dependencies = [
  "proc-exit",
  "sha2",
  "which",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -923,12 +889,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
 name = "serde"
 version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -975,12 +935,6 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
-
-[[package]]
-name = "smallvec"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "strsim"
@@ -1228,15 +1182,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -1260,21 +1205,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]

--- a/jump/Cargo.toml
+++ b/jump/Cargo.toml
@@ -41,4 +41,3 @@ rev = "b2276ef3fd039ed8565b4c1cbedb7a5aeeca734e"
 [dev-dependencies]
 ctor = "0.2"
 env_logger = { workspace = true }
-parking_lot = "0.12"

--- a/jump/Cargo.toml
+++ b/jump/Cargo.toml
@@ -5,7 +5,7 @@ description = "The bulk of the scie-jump binary logic."
 authors = [
     "John Sirois <john.sirois@gmail.com>",
 ]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [dependencies]

--- a/jump/src/cmd_env.rs
+++ b/jump/src/cmd_env.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 use std::ffi::OsString;
+
 use indexmap::IndexMap;
 
 use crate::config::{Cmd, EnvVar};
@@ -112,7 +113,11 @@ impl<'a> EnvParser<'a> {
             // If we're already calculating a Cmd env var value for `key`, we can only
             // pull references to that `key` needed to compute the value from the
             // ambient environment.
-            if let Some(val) = self.ambient_env.get(&OsString::from(&parsed_env.name)).and_then(|v| v.to_owned().into_string().ok()) {
+            if let Some(val) = self
+                .ambient_env
+                .get(&OsString::from(&parsed_env.name))
+                .and_then(|v| v.to_owned().into_string().ok())
+            {
                 val
             } else {
                 parsed_env.default.unwrap_or_default()
@@ -121,7 +126,11 @@ impl<'a> EnvParser<'a> {
             .env
             .get(&parsed_env.name)
             .map(|v| v.to_owned())
-            .or_else(|| self.ambient_env.get(&OsString::from(&parsed_env.name)).and_then(|v| v.to_owned().into_string().ok()))
+            .or_else(|| {
+                self.ambient_env
+                    .get(&OsString::from(&parsed_env.name))
+                    .and_then(|v| v.to_owned().into_string().ok())
+            })
         {
             self.parse_env_var(&parsed_env.name, &val)?
         } else {

--- a/jump/src/installer.rs
+++ b/jump/src/installer.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 use logging_timer::time;
 use zip::ZipArchive;
 
-use crate::atomic::{atomic_path, Target};
+use crate::atomic::{Target, atomic_path};
 use crate::config::{ArchiveType, Compression, FileType};
 use crate::context::FileEntry;
 use crate::fingerprint;
@@ -97,12 +97,12 @@ where
     })
 }
 
-#[cfg(not(target_family = "unix"))]
+#[cfg(windows)]
 fn executable_permissions() -> Option<Permissions> {
     None
 }
 
-#[cfg(target_family = "unix")]
+#[cfg(unix)]
 fn executable_permissions() -> Option<Permissions> {
     use std::os::unix::fs::PermissionsExt;
     Some(Permissions::from_mode(0o755))
@@ -210,8 +210,7 @@ impl<'a> Installer<'a> {
                                 {binding:?}: {e}"
                             )
                         })?;
-                        let mut child =
-                            binding.spawn_stdout(vec![file.name.as_str()].as_slice())?;
+                        let mut child = binding.spawn_stdout(&[file.name.as_str()])?;
                         let mut stdout = child.stdout.take().ok_or_else(|| {
                             format!(
                                 "Failed to grab stdout attempting to load {file:?} via binding."

--- a/jump/src/lift.rs
+++ b/jump/src/lift.rs
@@ -126,7 +126,7 @@ fn determine_file_type(path: &Path) -> Result<FileType, String> {
                     return Err(format!(
                         "This archive has no type declared and it could not be guessed from \
                             its name: {name}",
-                    ))
+                    ));
                 }
             };
             let file_type = if let Some(archive_type) = ArchiveType::from_ext(ext) {
@@ -143,12 +143,12 @@ fn determine_file_type(path: &Path) -> Result<FileType, String> {
     ))
 }
 
-#[cfg(not(target_family = "unix"))]
+#[cfg(windows)]
 fn is_executable(_path: &Path) -> Result<bool, String> {
     Ok(false)
 }
 
-#[cfg(target_family = "unix")]
+#[cfg(unix)]
 fn is_executable(path: &Path) -> Result<bool, String> {
     use std::os::unix::fs::PermissionsExt;
     let metadata = path.metadata().map_err(|e| {

--- a/jump/src/placeholders.rs
+++ b/jump/src/placeholders.rs
@@ -117,13 +117,13 @@ pub(crate) fn parse(text: &str) -> Result<Parsed, String> {
                                     "The {{scie.user.cache_dir}} requires a fallback value; e.g.: \
                                     {{scie.user.cache_dir=~/.cache}}"
                                         .to_string(),
-                                )
+                                );
                             }
                             _ => {
                                 return Err(format!(
                                     "Unrecognized placeholder in the {{scie.user.*}} \
                                     namespace: {{scie.user.{cache_dir}}}"
-                                ))
+                                ));
                             }
                         }
                     }
@@ -155,7 +155,7 @@ pub(crate) fn parse(text: &str) -> Result<Parsed, String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse, Item, Placeholder};
+    use super::{Item, Placeholder, parse};
     use crate::placeholders::ScieBindingEnv;
 
     #[test]

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -15,10 +15,10 @@ use sha2::{Digest, Sha256};
 
 const BINARY: &str = "scie-jump";
 
-#[cfg(target_family = "windows")]
+#[cfg(windows)]
 const PATHSEP: &str = ";";
 
-#[cfg(target_family = "unix")]
+#[cfg(not(windows))]
 const PATHSEP: &str = ":";
 
 fn add_magic(path: &Path) -> ExitResult {

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.85.1"
 components = [
   "cargo",
   "clippy",

--- a/src/boot/split.rs
+++ b/src/boot/split.rs
@@ -26,12 +26,12 @@ fn ensure_parent_dir(base: &Path, file: &File) -> Result<PathBuf, Exit> {
     Ok(dst)
 }
 
-#[cfg(not(target_family = "unix"))]
+#[cfg(windows)]
 fn executable_permissions() -> Option<Permissions> {
     None
 }
 
-#[cfg(target_family = "unix")]
+#[cfg(unix)]
 fn executable_permissions() -> Option<Permissions> {
     use std::os::unix::fs::PermissionsExt;
     Some(Permissions::from_mode(0o755))

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,26 @@
 // Copyright 2022 Science project contributors.
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+use std::collections::HashMap;
+use std::env;
 use std::ffi::OsString;
 
 use proc_exit::{Code, ExitResult};
 
 mod boot;
 
-use jump::BootAction;
+use jump::{BootAction, Process};
 
 #[cfg(windows)]
-fn exec(exe: OsString, args: Vec<OsString>, argv_skip: usize) -> ExitResult {
-    let result = jump::execute(exe, args, argv_skip);
+fn exec(
+    process: Process,
+    argv_skip: usize,
+    extra_env: Vec<(OsString, Option<OsString>)>,
+) -> ExitResult {
+    let result = process.execute(
+        env::args_os().skip(argv_skip).collect::<Vec<_>>(),
+        extra_env,
+    );
     match result {
         Ok(exit_status) => Code::from(exit_status).ok(),
         Err(message) => Err(Code::FAILURE.with_message(message)),
@@ -19,19 +28,25 @@ fn exec(exe: OsString, args: Vec<OsString>, argv_skip: usize) -> ExitResult {
 }
 
 #[cfg(unix)]
-fn exec(exe: OsString, args: Vec<OsString>, argv_skip: usize) -> ExitResult {
+fn exec(
+    process: Process,
+    argv_skip: usize,
+    extra_env: Vec<(OsString, Option<OsString>)>,
+) -> ExitResult {
     use std::ffi::CString;
     use std::os::unix::ffi::OsStringExt;
 
-    use nix::unistd::execv;
+    use nix::unistd::execve;
 
-    let c_exe = CString::new(exe.into_vec()).map_err(|e| {
+    let c_exe = CString::new(process.exe.into_vec()).map_err(|e| {
         Code::FAILURE.with_message(format!("Failed to convert executable to a C string: {e}",))
     })?;
 
     let mut c_args = vec![c_exe.clone()];
     c_args.extend(
-        args.into_iter()
+        process
+            .args
+            .into_iter()
             .chain(std::env::args().skip(argv_skip).map(OsString::from))
             .map(|arg| {
                 CString::new(arg.into_vec()).map_err(|e| {
@@ -42,7 +57,35 @@ fn exec(exe: OsString, args: Vec<OsString>, argv_skip: usize) -> ExitResult {
             .collect::<Result<Vec<_>, _>>()?,
     );
 
-    execv(&c_exe, &c_args)
+    let mut env = env::vars_os().collect::<HashMap<_, _>>();
+    for (name, value) in process
+        .env
+        .to_env_vars(env::vars_os())
+        .into_iter()
+        .chain(extra_env)
+    {
+        match value {
+            Some(val) => {
+                env.insert(name, val);
+            }
+            None => {
+                env.remove(&name);
+            }
+        }
+    }
+
+    let c_env = env
+        .into_iter()
+        .map(|(mut name, value)| {
+            name.push("=");
+            name.push(value);
+            CString::new(name.into_vec()).map_err(|e| {
+                Code::FAILURE.with_message(format!("Failed to convert env var to a C string: {e}"))
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    execve(&c_exe, &c_args, &c_env)
         .map_err(|e| {
             Code::new(e as i32).with_message(format!(
                 "Failed to exec {c_exe:?} with argv {c_args:?}: {e}"
@@ -61,10 +104,9 @@ fn main() -> ExitResult {
     })?;
 
     match action {
-        BootAction::Execute((process, argv1_consumed)) => {
-            process.env.export();
+        BootAction::Execute((process, argv1_consumed, extra_env)) => {
             let argv_skip = if argv1_consumed { 2 } else { 1 };
-            exec(process.exe, process.args, argv_skip)
+            exec(process, argv_skip, extra_env)
         }
         BootAction::Help((message, exit_code)) => boot::help(message, exit_code),
         BootAction::Inspect((jump, lift)) => boot::inspect(jump, lift),


### PR DESCRIPTION
Announcement: https://blog.rust-lang.org/2025/03/18/Rust-1.85.1.html

The jump crate was left back on the 2021 edition during the 1.85.0
upgrade since env var mutation is now unsafe and the changes to avoid
these mutations are a bit extensive. This change bites that bullet.