### PR TITLE
Upgrade to Rust 1.86.0

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.85.1"
+channel = "1.86.0"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
Announcement: https://blog.rust-lang.org/2025/04/03/Rust-1.86.0.html