### PR TITLE
Support `scie.argv0` & `scie.env.SCIE{,_ARGV0}`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 1.7.0
+
+Add support for the `{scie.argv0}` placeholder and plumb `SCIE` and `SCIE_ARGV0` env vars into
+the `{scie.env.SCIE}` and `{scie.env.SCIE_ARGV0}` env var placeholders respectively. Previously
+these two env vars were set and observable by the executing command, but they were not available
+for env var substitutions.
+
 ## 1.6.1
 
 The `SCIE=split` file selection feature now warns when selected files can't be found in the scie.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "scie-jump"
-version = "1.6.1"
+version = "1.7.0"
 dependencies = [
  "env_logger",
  "jump",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 
 [package]
 name = "scie-jump"
-version = "1.6.1"
+version = "1.7.0"
 description = "The self contained interpreted executable launcher."
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -381,14 +381,17 @@ Runtime external control variables:
 Runtime read-only variables:
 
 + `SCIE`: The absolute path of the scie executable. This can be used to re-execute the scie.
-+ `SCIE_ARGV0`: The value of the 1st command line argument. If the scie was launched via a symlink
-  The symlink name will be preserved here whereas it would be resolved in `SCIE` on Unix systems.
-  This can be used to implement BusyBox-style re-direction.
++ `SCIE_ARGV0`: The value of the 1st command line argument the scie was launched with. If the scie
+  was launched via a symlink The symlink name will be preserved here whereas it would be resolved
+  in `SCIE` on Unix systems. This can be used to implement BusyBox-style re-direction.
 
 ## Advanced placeholders
 
 Further placeholders you can use in command "exe", "args" and "env" values include:
 
++ `{scie}`: The absolute path of the scie executable. The same as the `SCIE` environment variable.
++ `{scie.argv0}`: The value of the 1st command line argument the scie was launched with. The same as
+  the `SCIE_ARGV0` environment variable.
 + `{scie.base}`: The value of the active `SCIE_BASE`.
 + `{scie.env.<env var name>[=<default env var value>]}`: This expands to the value of the env var
   named. If the env var is not in the ambient runtime environment or the defined command environment

--- a/jump/src/cmd_env.rs
+++ b/jump/src/cmd_env.rs
@@ -85,6 +85,7 @@ impl<'a> EnvParser<'a> {
                     reified.push_str(&format!("{{scie.user.cache_dir={fallback}}}"))
                 }
                 Item::Placeholder(Placeholder::Scie) => reified.push_str("{scie}"),
+                Item::Placeholder(Placeholder::ScieArgv0) => reified.push_str("{scie.argv0}"),
                 Item::Placeholder(Placeholder::ScieBase) => reified.push_str("{scie.base}"),
                 Item::Placeholder(Placeholder::ScieBindings) => reified.push_str("{scie.bindings}"),
                 Item::Placeholder(Placeholder::ScieBindingCmd(cmd)) => {

--- a/jump/src/lib.rs
+++ b/jump/src/lib.rs
@@ -25,7 +25,7 @@ use std::collections::HashMap;
 use std::env;
 use std::env::current_exe;
 use std::ffi::OsString;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use itertools::Itertools;
 use log::Level;
@@ -107,12 +107,20 @@ pub fn config(jump: Jump, mut lift: Lift) -> Config {
     Config::new(jump, lift, other)
 }
 
+#[derive(Debug)]
 pub struct CurrentExe {
     exe: PathBuf,
     invoked_as: PathBuf,
 }
 
 impl CurrentExe {
+    pub fn from_path(exe: &Path) -> Self {
+        CurrentExe {
+            exe: exe.to_path_buf(),
+            invoked_as: exe.to_path_buf(),
+        }
+    }
+
     pub fn name(&self) -> Option<&str> {
         #[cfg(windows)]
         let invoked_as = self.invoked_as.file_stem();

--- a/jump/src/placeholders.rs
+++ b/jump/src/placeholders.rs
@@ -16,6 +16,7 @@ pub(crate) enum Placeholder<'a> {
     FileName(&'a str),
     UserCacheDir(&'a str),
     Scie,
+    ScieArgv0,
     ScieBase,
     ScieBindings,
     ScieBindingCmd(&'a str),
@@ -86,6 +87,7 @@ pub(crate) fn parse(text: &str) -> Result<Parsed, String> {
                 }
                 match symbol.splitn(3, '.').collect::<Vec<_>>()[..] {
                     ["scie"] => items.push(Item::Placeholder(Placeholder::Scie)),
+                    ["scie", "argv0"] => items.push(Item::Placeholder(Placeholder::ScieArgv0)),
                     ["scie", "base"] => items.push(Item::Placeholder(Placeholder::ScieBase)),
                     ["scie", "bindings"] => {
                         items.push(Item::Placeholder(Placeholder::ScieBindings))


### PR DESCRIPTION
Although the `SCIE` and `SCIE_ARGV0` env vars were already populated 
for scies to observe at runtime, they were not previously available for
substitution in placeholders at boot time.

Motivated by https://github.com/pex-tool/pex/issues/2733, but a glaring
hole on its own.