### PR TITLE
Upgrade to Rust 1.88.0.

### DIFF
--- a/jump/src/placeholders.rs
+++ b/jump/src/placeholders.rs
@@ -54,7 +54,7 @@ pub(crate) fn parse(text: &str) -> Result<Parsed, String> {
                 .to_string(),
         );
     }
-    for (index, current_char) in text.chars().enumerate() {
+    for (index, current_char) in text.char_indices() {
         match current_char {
             '{' if inside_placeholder == 0 => {
                 if index - start > 0 {

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.87.0"
+channel = "1.88.0"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
Release announcement: https://blog.rust-lang.org/2025/06/26/Rust-1.88.0/