### PR TITLE
Upgrade Rust to 1.91.1.

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.91.0"
+channel = "1.91.1"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
The release announcement is here:
  https://blog.rust-lang.org/2025/11/10/Rust-1.91.1/