### PR TITLE
Upgrade Rust to 1.96.0.

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.0"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
The release announcement is here:
  https://blog.rust-lang.org/2026/05/28/Rust-1.96.0/