### PR TITLE
Upgrade to Rust 1.96.1.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,9 +485,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]

--- a/jump/Cargo.toml
+++ b/jump/Cargo.toml
@@ -16,7 +16,7 @@ fd-lock = "4.0"
 flate2 = "1.0"  # For gz support.
 hex = { workspace = true }
 indexmap = { version = "2.8", features = ["serde"] }
-itertools = "0.14"
+itertools = "0.15"
 log = { workspace = true }
 logging_timer = { workspace = true }
 os_str_bytes = { version = "7.1", features = ["conversions"] }

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -180,7 +180,13 @@ fn main() -> ExitResult {
             .env(
                 "PATH",
                 [output_bin_dir.to_str().unwrap(), env!("PATH")].join(PATHSEP),
-            ),
+            )
+            // N.B.: This avoids a spurious warning of this sort:
+            // warning: default toolchain implicitly overridden with `1.96.0-x86_64-unknown-linux-gnu` by rustup toolchain file
+            //   |
+            //   = help: use `cargo +stable install` if you meant to use the stable toolchain
+            //   = note: rustup selects the toolchain based on the parent environment and not the environment of the package being installed
+            .env_remove("RUSTUP_TOOLCHAIN_SOURCE"),
     )?;
     let src = output_bin_dir
         .join(BINARY)

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.96.0"
+channel = "1.96.1"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
The release announcement is here:
  https://blog.rust-lang.org/2026/06/30/Rust-1.96.1/