### PR TITLE
Upgrade to Rust 1.97.0.

### DIFF
--- a/jump/src/context.rs
+++ b/jump/src/context.rs
@@ -235,7 +235,7 @@ impl Binding {
         F: FnOnce() -> Result<(), String>,
     {
         if let Some(env) = atomic_path(self.target.as_path(), Target::File, |lock| {
-            trace!("Installing boot binding {binding:#?}", binding = &self);
+            trace!("Installing boot binding {binding:#?}", binding = self);
             install_required_files()?;
 
             let result = self

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.96.1"
+channel = "1.97.0"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
The release announcement is here:
  https://blog.rust-lang.org/2026/07/09/Rust-1.97.0/