### PR TITLE
Set a default bin for cargo run.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
 
 [package]
 name = "scie-jump"
+default-run = "scie-jump"
 version = "1.12.0"
 description = "The self contained interpreted executable launcher."
 authors = [


### PR DESCRIPTION
This is not useful yet, since `scie-jump` is only runnable when
post-processed through `cargo run -p package`.